### PR TITLE
feat: add CI/CD workflow for frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.pnpm-store
+dist
+.git
+.github
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - development
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI/CD Frontend
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install git
+        run: apk add --no-cache git || apt-get install -y git
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: |
+          pnpm config set store-dir .pnpm-store
+          pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
+
+  test:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install git
+        run: apk add --no-cache git || apt-get install -y git
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: |
+          pnpm config set store-dir .pnpm-store
+          pnpm install --frozen-lockfile
+      - name: Test
+        run: pnpm run test:check
+
+  secret-detection:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-build-push:
+    runs-on: self-hosted
+    needs: [build, test, secret-detection]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+      - name: Build and push
+        run: |
+          IMAGE_TAG=${{ secrets.ECR_REGISTRY }}/salespilot/web:${{ github.sha }}
+          docker build -t $IMAGE_TAG .
+          docker push $IMAGE_TAG

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
+          version: 9
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install git
-        run: sudo apt get install -y git
+        run: sudo apt-get install -y git
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,21 @@ on:
       - development
 
 jobs:
-  build:
+  build-and-test:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
       - name: Install dependencies
-        run: |
-          pnpm config set store-dir .pnpm-store
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build
-
-  test:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          pnpm config set store-dir .pnpm-store
-          pnpm install --frozen-lockfile
       - name: Test
         run: pnpm run test:check
 
@@ -45,7 +41,7 @@ jobs:
 
   docker-build-push:
     runs-on: self-hosted
-    needs: [build, test, secret-detection]
+    needs: [build-and-test, secret-detection]
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/path zricethezav/gitleaks:latest detect --source /path --exit-code 1
 
   docker-build-push:
     runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install git
-        run: apk add --no-cache git || apt-get install -y git
+        run: sudo apt-get install -y git
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install git
-        run: apk add --no-cache git || apt-get install -y git
+        run: sudo apt get install -y git
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
-      - name: Install git
-        run: sudo apt-get install -y git
-      - name: Install pnpm
-        run: npm install -g pnpm
       - name: Install dependencies
         run: |
           pnpm config set store-dir .pnpm-store
@@ -30,10 +26,6 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
-      - name: Install git
-        run: sudo apt-get install -y git
-      - name: Install pnpm
-        run: npm install -g pnpm
       - name: Install dependencies
         run: |
           pnpm config set store-dir .pnpm-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
-RUN pnpm run build
+RUN pnpm build
 
 FROM nginx:alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm run build
+
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@9",
   "scripts": {
     "prepare": "lefthook install",
     "dev": "vite",


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

Adicionado o arquivo `.github/workflows/ci.yml` no repositório do frontend. O pipeline conta com as stages de `build` (instalação de dependências com pnpm e build do React), `test` (execução dos testes com vitest), `security` (detecção de secrets com Gitleaks) e `docker` (build e push da imagem para o ECR em `salespilot/web`). O frontend não possui stage de deploy — a responsabilidade de subir os containers fica centralizada no pipeline do backend.

## Por que essa mudança é necessária?

Para automatizar o build e a entrega da imagem do frontend ao ECR a cada merge na `main`, eliminando a necessidade de build e push manual.

## Como testar?

Abrir um PR apontando para `main` e verificar se as stages de `build`, `test` e `secret-detection` rodam. Após merge na `main`, verificar se a stage `docker-build-push` executa com sucesso e se a imagem aparece no ECR em `salespilot/web`.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o PR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças