### PR TITLE
feat: add mirror script (gitlab <-> github)

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,21 @@
+name: Mirror to GitLab SalesPilot
+
+on:
+  push:
+    branches:
+      - main
+      - development
+
+jobs:
+  git-mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to SalesPilot GitLab
+        run: |
+          git remote add gitlab https://${{ secrets.GITLAB_USERNAME }}:${{ secrets.GITLAB_TOKEN }}@tools.ages.pucrs.br/salespilot/frontend.git
+          
+          git push gitlab HEAD:refs/heads/${{ github.ref_name }} --force


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

Script de mirror para o GitLab estar atualizado com as mudanças mais recentes do GitHub. Isso inclui as branches main e development.

## Por que essa mudança é necessária?

É requisito mantermos o GitLab atualizado.

## Como testar?

Push de qualquer commit para a dev e conferir se o GitLab atualizou. Foram definidas duas variáveis secretas no projeto para isso:
`GITLAB_USERNAME` -> nome do bot de mirror
`GITLAB_TOKEN` -> token de autenticação geral do projeto

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças