### PR TITLE
fix(ci): remove redundant pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Issue relacionada                                                           
                                                                                
  N/A                                                                           
                                                                                
 ## O que foi implementado?                                                       
                                                                                
  Removido o campo version: 9 do step pnpm/action-setup@v4 no workflow de CI.   
                                             
  ## Por que essa mudança é necessária?                                            
                                             
  A versão do pnpm estava sendo declarada em dois lugares: no workflow (version:9) e no package.json ("packageManager": "pnpm@9"). O pnpm/action-setup@v4 detecta ambos e lança erro de conflito, quebrando a pipeline. Removendo o version do workflow, a action lê a versão diretamente do campo packageManager do package.json, que é a fonte de verdade.

  ## Como testar?
Abrir um PR apontando para main ou development e verificar que o job build-and-test passa o step de setup do pnpm sem erro.