### PR TITLE
fix: restore sentiment and duration icons after merge changes

### DIFF
--- a/src/UI/AppIcon/AppIcon.tsx
+++ b/src/UI/AppIcon/AppIcon.tsx
@@ -1,4 +1,5 @@
 import type { TIconName } from '@declarations';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import ApartmentIcon from '@mui/icons-material/Apartment';
 import CloseIcon from '@mui/icons-material/Close';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -9,6 +10,9 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import PersonIcon from '@mui/icons-material/Person';
 import SaveIcon from '@mui/icons-material/Save';
+import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
+import SentimentNeutralIcon from '@mui/icons-material/SentimentNeutral';
+import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
 import type { JSX } from 'react';
 
 export const GetAppIcon = (name: TIconName): JSX.Element => {
@@ -25,6 +29,14 @@ export const GetAppIcon = (name: TIconName): JSX.Element => {
       return <PersonIcon />;
     case 'meeting':
       return <EventNoteIcon />;
+    case 'duration':
+      return <AccessTimeIcon />;
+    case 'sentimentSad':
+      return <SentimentDissatisfiedIcon />;
+    case 'sentimentNeutral':
+      return <SentimentNeutralIcon />;
+    case 'sentimentHappy':
+      return <SentimentSatisfiedAltIcon />;
     case 'login':
       return <LoginIcon />;
     case 'logout':

--- a/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
+++ b/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
@@ -156,7 +156,7 @@ export const AdminMeetingsPage = (): JSX.Element => {
           />
 
           <StatCard
-            iconName="clock"
+            iconName="duration"
             theme="neutrals"
             value={
               summary

--- a/src/types/ui.d.ts
+++ b/src/types/ui.d.ts
@@ -17,6 +17,7 @@ export type TIconName =
   | 'logout'
   | 'close'
   | 'save'
+  | 'duration'
   | 'sentimentSad'
   | 'sentimentNeutral'
   | 'sentimentHappy';


### PR DESCRIPTION
## Issue relacionada

N/A

## O que foi implementado?

Correção dos ícones utilizados nos StatCards de reuniões.

* Adição dos ícones:
    * duration
    * sentimentSad
    * sentimentNeutral
    * sentimentHappy
* Atualização do GetAppIcon para suportar esses novos ícones
* Atualização do tipo TIconName

## Por que essa mudança é necessária?

Após um merge recente, os ícones de duração e sentimento deixaram de funcionar corretamente, pois os novos nomes utilizados pelo useSentiment não estavam mapeados no AppIcon.

Essa correção garante que:

* os ícones sejam exibidos corretamente
* o comportamento do useSentiment funcione como esperado
* a UI fique consistente com o design
 
## Como testar?

* Acessar a tela de listagem de reuniões
* Verificar:
    * Ícone de duração (⏱)
    * Ícones de sentimento (🙂 😐 ☹️) variando conforme valor
* Garantir que não aparece mais o ícone padrão (raio ⚡)
 
## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças