### PR TITLE
fix: correct meetings schema and mapping to match new backend contract

### DIFF
--- a/src/services/api/meeting.ts
+++ b/src/services/api/meeting.ts
@@ -35,7 +35,7 @@ export const meetingApi = {
 
     return {
       content: parsedResponse.content.map(mapMeetingListItem),
-      totalElements: parsedResponse.totalElements,
+      totalElements: parsedResponse.total_elements,
       summary: parsedResponse.summary,
     };
   },

--- a/src/services/models/MeetingSchema.ts
+++ b/src/services/models/MeetingSchema.ts
@@ -21,8 +21,8 @@ export const MeetingListItemApiSchema = z.object({
   meeting_type: z.string(),
 
   scheduled_for: z.string(),
-  started_at: z.string(),
-  ended_at: z.string(),
+  started_at: z.string().nullable(),
+  ended_at: z.string().nullable(),
 
   duration_seconds: z.number(),
   status: z.string(),
@@ -42,7 +42,8 @@ export const MeetingSummarySchema = z.object({
  */
 export const MeetingsResponseSchema = z.object({
   content: z.array(MeetingListItemApiSchema),
-  totalElements: z.number(),
+  total_elements: z.number(),
+  total_pages: z.number(),
   summary: MeetingSummarySchema,
 });
 


### PR DESCRIPTION
## Issue relacionada

#8 

## O que foi implementado?

Correção da integração da listagem de reuniões com o backend.

Ajustes realizados

* Atualização do MeetingsResponseSchema para refletir corretamente o contrato da API:
    * totalElements → total_elements
    * inclusão de total_pages
* Ajuste de campos opcionais:
    * started_at e ended_at agora aceitam null
* Correção no mapeamento da resposta:
    * uso de parsedResponse.total_elements
* Ajuste do schema de seller para incluir email

## Por que essa mudança é necessária?

A estrutura retornada pelo backend não estava compatível com o schema definido no frontend, causando falha no parse do Zod.

Como consequência:

* a query falhava silenciosamente
* a tabela de reuniões não exibia dados

Essa correção garante que:

* os dados sejam corretamente validados
* o frontend consiga consumir a API sem erros
* a listagem de reuniões funcione como esperado

## Como testar?

1. Garantir que o backend esteja rodando
2. Acessar a tela de reuniões (/admin/reuniões)
3. Verificar:
    * Se a lista de reuniões está sendo exibida
    * Se os dados (título, vendedor, empresa, data, duração) aparecem corretamente
    * Se os StatCards estão sendo preenchidos

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças
