### PR TITLE
feat: create salesman detail screen

### DIFF
--- a/src/data/enums/EPageRoutes.ts
+++ b/src/data/enums/EPageRoutes.ts
@@ -6,5 +6,6 @@ export const EPageRoutes = {
   MANAGERS: '/gestores',
   MANAGER_DETAIL: '/gestores/$id',
   SALESMEN: '/vendedores',
+  SALESMAN_DETAIL: '/vendedores/$id',
   MEETINGS: '/reuniões',
 } as const;

--- a/src/data/enums/EPageTitles.ts
+++ b/src/data/enums/EPageTitles.ts
@@ -7,5 +7,6 @@ export const EPageTitles = {
   MANAGERS: 'Gestores',
   MANAGER_INFORMATION: 'Informações do gestor',
   SALESMEN: 'Vendedores',
+  SALESMAN_INFORMATION: 'Informações do vendedor',
   MEETINGS: 'Reuniões',
 };

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
@@ -1,0 +1,95 @@
+import type { TSalesman } from '@services/models/SalesmanSchema';
+import { fireEvent, render, screen } from '@tests/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useParams: () => ({ id: 'sls-1' }),
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  };
+});
+
+vi.mock('@services/queries/useSalesmen', () => ({
+  useGetSalesmanById: vi.fn(),
+}));
+
+vi.mock('@pages/PageNotFound/PageNotFound', () => ({
+  PageNotFound: () => <div data-testid="not-found" />,
+}));
+
+import { useGetSalesmanById } from '@services/queries/useSalesmen';
+
+import { SalesmanDetail } from './SalesmanDetail';
+
+const mockQuery = useGetSalesmanById as ReturnType<typeof vi.fn>;
+
+const salesman: TSalesman = {
+  id: 'sls-1',
+  name: 'Marta Costa',
+  email: 'marta@digitalsales.com',
+  company: { id: 'co-1', name: 'Digital Sales' },
+  active: true,
+  preferences: null,
+};
+
+describe('SalesmanDetail', () => {
+  it('shows loading state', () => {
+    mockQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<SalesmanDetail />);
+
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument();
+  });
+
+  it('shows PageNotFound on error', () => {
+    mockQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<SalesmanDetail />);
+
+    expect(screen.getByTestId('not-found')).toBeInTheDocument();
+  });
+
+  it('renders salesman detail information', () => {
+    mockQuery.mockReturnValue({
+      data: salesman,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SalesmanDetail />);
+
+    expect(screen.getByText(/voltar para vendedores/i)).toBeInTheDocument();
+    expect(screen.getAllByText('Marta Costa').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('marta@digitalsales.com')).toBeInTheDocument();
+    expect(screen.getByText('Digital Sales')).toBeInTheDocument();
+    expect(screen.getByText('Ativo')).toBeInTheDocument();
+  });
+
+  it('transitions to edit mode when Editar is clicked', () => {
+    mockQuery.mockReturnValue({
+      data: salesman,
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SalesmanDetail />);
+
+    fireEvent.click(screen.getByRole('button', { name: /editar/i }));
+
+    expect(screen.getByText(/modo de edição iniciado/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /cancelar/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -1,0 +1,148 @@
+import { EPageRoutes } from '@data/enums/EPageRoutes';
+import { EPageTitles } from '@data/enums/EPageTitles';
+import { ArrowBack, Business, Close, Email } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Link as MuiLink,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { PageNotFound } from '@pages/PageNotFound/PageNotFound';
+import { useGetSalesmanById } from '@services/queries/useSalesmen';
+import { Link, useParams } from '@tanstack/react-router';
+import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
+import { IconBox } from '@UI/IconBox/IconBox';
+import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
+import { PageContainter } from '@UI/PageContainer/PageContainer';
+import { PageHeader } from '@UI/PageHeader/PageHeader';
+import { StatusBadge } from '@UI/StatusBadge/StatusBadge';
+import { type JSX, useState } from 'react';
+
+export const SalesmanDetail = (): JSX.Element => {
+  const { palette } = useTheme();
+  const { id } = useParams({ strict: false }) as { id: string };
+  const { data: salesman, isLoading, isError } = useGetSalesmanById(id ?? null);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleStartEdit = (): void => {
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = (): void => {
+    setIsEditing(false);
+  };
+
+  if (isLoading) {
+    return (
+      <PageContainter>
+        <Typography>Carregando informações do vendedor...</Typography>
+      </PageContainter>
+    );
+  }
+
+  if (isError || !salesman) {
+    return <PageNotFound />;
+  }
+
+  return (
+    <PageContainter>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2rem',
+          width: '100%',
+        }}
+      >
+        <MuiLink
+          component={Link}
+          to={EPageRoutes.SALESMEN}
+          underline="hover"
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.75,
+            color: palette.primary[600],
+            fontWeight: 500,
+            width: 'fit-content',
+            fontSize: '0.875rem',
+          }}
+        >
+          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          Voltar para vendedores
+        </MuiLink>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
+          <IconBox iconName="salesman" theme="salesmen" />
+          <PageHeader title={salesman.name} subtitle="" />
+        </Box>
+
+        <EntityDetailsCard
+          title={EPageTitles.SALESMAN_INFORMATION}
+          onEdit={isEditing ? undefined : handleStartEdit}
+          headerRight={
+            isEditing ? (
+              <Box
+                sx={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}
+              >
+                <Button
+                  variant="outlined"
+                  startIcon={<Close />}
+                  onClick={handleCancelEdit}
+                >
+                  Cancelar
+                </Button>
+              </Box>
+            ) : undefined
+          }
+        >
+          {isEditing ? (
+            <Box
+              sx={{
+                border: `1px dashed ${palette.neutrals[300]}`,
+                borderRadius: '0.75rem',
+                padding: '1rem',
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                Modo de edição iniciado. A edição completa será implementada na
+                FE-12.
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                gap: '2rem 4rem',
+              }}
+            >
+              <ItemDetail label="ID do usuário" value={salesman.id} />
+
+              <ItemDetail
+                label="Empresa"
+                value={salesman.company.name}
+                icon={<Business fontSize="small" />}
+              />
+
+              <ItemDetail label="Nome do usuário" value={salesman.name} />
+
+              <ItemDetail label="Status">
+                <Box sx={{ display: 'inline-flex', alignSelf: 'flex-start' }}>
+                  <StatusBadge active={salesman.active} />
+                </Box>
+              </ItemDetail>
+
+              <ItemDetail
+                label="Email de acesso"
+                value={salesman.email}
+                icon={<Email fontSize="small" />}
+              />
+            </Box>
+          )}
+        </EntityDetailsCard>
+      </Box>
+    </PageContainter>
+  );
+};

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import { ManagersPage } from '@pages/ManagersPage/ManagersPage';
 import { MeetingsPage } from '@pages/MeetingsPage/MeetingsPage';
 import { PageNotFound } from '@pages/PageNotFound/PageNotFound';
 import { RootComponent } from '@pages/RootComponent/RootComponent';
+import { SalesmanDetail } from '@pages/SalesmenPage/SalesmanDetail/SalesmanDetail';
 import { SalesmenPage } from '@pages/SalesmenPage/SalesmenPage';
 import { useAuthStore } from '@store/authStore';
 import {
@@ -103,6 +104,13 @@ const salesmenRoute = createRoute({
   beforeLoad: requireAdminOrManager,
 });
 
+const salesmanDetailRoute = createRoute({
+  getParentRoute: () => protectedRoute,
+  path: EPageRoutes.SALESMAN_DETAIL,
+  component: SalesmanDetail,
+  beforeLoad: requireAdminOrManager,
+});
+
 const meetingsRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: EPageRoutes.MEETINGS,
@@ -121,6 +129,7 @@ const routeTree = rootRoute.addChildren([
       managerDetailRoute,
     ]),
     salesmenRoute,
+    salesmanDetailRoute,
     meetingsRoute,
   ]),
 ]);

--- a/src/services/api/apiClient.ts
+++ b/src/services/api/apiClient.ts
@@ -3,8 +3,10 @@ import axios from 'axios';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
+const normalizedBaseUrl = API_URL.replace(/\/+$/, '').replace(/\/api$/, '');
+
 const apiClient: AxiosInstance = axios.create({
-  baseURL: API_URL,
+  baseURL: normalizedBaseUrl,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/src/services/api/salesman.ts
+++ b/src/services/api/salesman.ts
@@ -1,0 +1,47 @@
+import type { TSalesman } from '@services/models/SalesmanSchema';
+import {
+  SalesmanListSchema,
+  SalesmanSchema,
+} from '@services/models/SalesmanSchema';
+
+import apiClient from './apiClient';
+
+const fetchSellerList = async (): Promise<TSalesman[]> => {
+  const response = await apiClient.get('/api/collaborators/sellers', {
+    params: {
+      page: 0,
+      size: 200,
+    },
+  });
+
+  const parsed = SalesmanListSchema.parse(response.data);
+  return parsed.content;
+};
+
+/**
+ * @description API service for salesman-related operations.
+ */
+export const salesmanApi = {
+  /**
+   * @description Get a single salesman by its UUID.
+   * @param {string} uuid - The UUID of the salesman to fetch.
+   * @returns {Promise<TSalesman>} A promise that resolves to the salesman data.
+   */
+  getSalesmanById: async (uuid: string): Promise<TSalesman> => {
+    try {
+      const response = await apiClient.get<TSalesman>(
+        `/api/collaborators/sellers/${uuid}`
+      );
+      return SalesmanSchema.parse(response.data);
+    } catch {
+      const sellers = await fetchSellerList();
+      const seller = sellers.find((row) => row.id === uuid);
+
+      if (!seller) {
+        throw new Error('Seller not found');
+      }
+
+      return seller;
+    }
+  },
+};

--- a/src/services/models/SalesmanSchema.ts
+++ b/src/services/models/SalesmanSchema.ts
@@ -1,0 +1,30 @@
+import z from 'zod';
+
+/**
+ * @description Zod schema for a single salesman.
+ */
+export const SalesmanSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+  company: z.object({ id: z.string(), name: z.string() }),
+  active: z.boolean(),
+  preferences: z
+    .object({
+      theme: z.string().nullable(),
+      default_model: z.string().nullable(),
+    })
+    .nullable()
+    .optional(),
+  created_at: z.string().optional(),
+});
+
+/**
+ * @description Zod schema for a paginated list of salesmen.
+ */
+export const SalesmanListSchema = z.object({
+  content: z.array(SalesmanSchema),
+});
+
+export type TSalesman = z.infer<typeof SalesmanSchema>;
+export type TSalesmanList = z.infer<typeof SalesmanListSchema>;

--- a/src/services/queries/useSalesmen.ts
+++ b/src/services/queries/useSalesmen.ts
@@ -1,0 +1,32 @@
+import { salesmanApi } from '@services/api/salesman';
+import type { TSalesman } from '@services/models/SalesmanSchema';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * @description Query keys for salesmen details.
+ */
+export const salesmenQueryKeys = {
+  all: ['salesmen'] as const,
+  details: () => [...salesmenQueryKeys.all, 'detail'] as const,
+  detail: (id: string) => [...salesmenQueryKeys.details(), id] as const,
+};
+
+/**
+ * @description A query to get a salesman by its ID.
+ * @param {string | null} uuid - The ID of the salesman to fetch.
+ * @param {UseQueryOptions<TSalesman>} options - Additional query options.
+ * @returns {ReturnType<typeof useQuery<TSalesman, Error>>} The query result.
+ */
+export const useGetSalesmanById = (
+  uuid: string | null,
+  options?: UseQueryOptions<TSalesman>
+): ReturnType<typeof useQuery<TSalesman, Error>> => {
+  return useQuery<TSalesman, Error>({
+    queryKey: salesmenQueryKeys.detail(uuid || ''),
+    queryFn: () => salesmanApi.getSalesmanById(uuid!),
+    enabled: !!uuid,
+    staleTime: 1000 * 60 * 5,
+    ...options,
+  });
+};

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,6 @@
 import { mockUsers } from '@data/mocks/Users';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { User, UserRole } from '../types/index';
 
@@ -15,28 +16,43 @@ interface AuthState {
 }
 
 const MOCK_PASSWORD = 'password';
+const AUTH_STORAGE_KEY = 'salespilot-auth';
 
-export const useAuthStore = create<AuthState>((set, get) => ({
-  user: null,
-  isAuthenticated: false,
-  setUser: (user: User | null): void =>
-    set({ user, isAuthenticated: user !== null }),
-  logout: (): void => set({ user: null, isAuthenticated: false }),
-  loginUser: (email: string, password: string): User | null => {
-    if (password !== MOCK_PASSWORD) {
-      return null;
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      isAuthenticated: false,
+      setUser: (user: User | null): void =>
+        set({ user, isAuthenticated: user !== null }),
+      logout: (): void => set({ user: null, isAuthenticated: false }),
+      loginUser: (email: string, password: string): User | null => {
+        if (password !== MOCK_PASSWORD) {
+          return null;
+        }
+
+        const user = mockUsers.find((u) => u.email === email);
+        if (user) {
+          set({ user, isAuthenticated: true });
+          return user;
+        }
+
+        return null;
+      },
+      getCurrentUser: (): User | null => get().user,
+      getCurrentUsername: (): string | null => get().user?.name || null,
+      getCurrentUserRole: (): UserRole | null => get().user?.role || null,
+    }),
+    {
+      name: AUTH_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+      }),
     }
-    const user = mockUsers.find((u) => u.email === email);
-    if (user) {
-      set({ user, isAuthenticated: true });
-      return user;
-    }
-    return null;
-  },
-  getCurrentUser: (): User | null => get().user,
-  getCurrentUsername: (): string | null => get().user?.name || null,
-  getCurrentUserRole: (): UserRole | null => get().user?.role || null,
-}));
+  )
+);
 
 export type { User, UserRole } from '@declarations';
 export const selectUser = (state: AuthState): User | null => state.user;

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -23,9 +23,12 @@ export const useAuthStore = create<AuthState>()(
     (set, get) => ({
       user: null,
       isAuthenticated: false,
-      setUser: (user: User | null): void =>
-        set({ user, isAuthenticated: user !== null }),
-      logout: (): void => set({ user: null, isAuthenticated: false }),
+      setUser: (user: User | null): void => {
+        set({ user, isAuthenticated: user !== null });
+      },
+      logout: (): void => {
+        set({ user: null, isAuthenticated: false });
+      },
       loginUser: (email: string, password: string): User | null => {
         if (password !== MOCK_PASSWORD) {
           return null;


### PR DESCRIPTION
## Issue relacionada

[<!-- Link da issue no GitHub. -->]

(https://github.com/SalesPilot-AGES/Frontend/issues/6)

## O que foi implementado?

 - Criação da tela de detalhe do vendedor em:
      - src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
  - Estrutura alinhada ao padrão do projeto (mesma base de ManagersDetails):
      - link “Voltar para vendedores”
      - cabeçalho com IconBox + nome do vendedor
      - EntityDetailsCard em modo leitura com grid de 2 colunas
      - ItemDetail para ID, nome, e-mail, empresa e status (StatusBadge)
      - botão Editar com transição para modo de edição (placeholder para FE-12)
  - Inclusão de teste unitário:
      - src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
  - Integração de rota:
      - EPageRoutes.SALESMAN_DETAIL
      - registro no router.tsx
  - Inclusão de título da seção:
      - EPageTitles.SALESMAN_INFORMATION

  ### Ajustes de comunicação com o backend

  Durante a implementação, foram necessários ajustes para compatibilizar frontend e backend local:

  - Endpoint de vendedor:
      - frontend inicialmente usava salesmen
      - backend expõe sellers
      - ajuste realizado em src/services/api/salesman.ts
  - Endpoint de detalhe por ID:
      - GET /api/collaborators/sellers/{id} no backend local responde 405 (Method Not Allowed)
      - implementado fallback: buscar lista de sellers e filtrar por id
  - Prefixo de API duplicado (/api/api/...):
      - .env.local já aponta para .../api
      - paths também tinham /api/...
      - ajuste em src/services/api/apiClient.ts para normalizar a base e evitar duplicação

  ### Persistência de autenticação

  - Implementada persistência de auth no zustand com persist + localStorage (salespilot-auth)
  - Isso evita redirecionamento indevido para /login ao acessar rota de detalhe via URL direta após refresh

## Por que essa mudança é necessária?

  - Entregar a FE-11 com a tela de detalhes do vendedor no mesmo padrão visual e arquitetural já existente no projeto.
  - Garantir que a navegação por rota de detalhe funcione de forma estável no MVP.
  - Corrigir incompatibilidades reais de integração com o backend para que a tela seja utilizável em ambiente local.

## Como testar?

 1. Rodar frontend e backend local.
  2. Fazer login com usuário admin ou manager (password).
  3. Acessar uma rota de detalhe válida:
      - /vendedores/{id}
  4. Validar:
      - link de voltar
      - cabeçalho com nome
      - card com informações em leitura
      - status em StatusBadge
      - botão Editar alternando para modo de edição (placeholder FE-12)
  5. Validar integração backend:
      - a tela deve carregar mesmo sem GET /sellers/{id} disponível (fallback por listagem).
      
<img width="1918" height="906" alt="image" src="https://github.com/user-attachments/assets/73db5bb5-c029-4f73-a2dd-a9758fb989f7" />
<img width="1870" height="978" alt="image" src="https://github.com/user-attachments/assets/7d74a65e-f0e5-44f9-902a-ab107364b56b" />



## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
