### PR TITLE
fix: cleanup company selectors and fix layout issues

### DIFF
--- a/src/UI/DataTable/DataTable.tsx
+++ b/src/UI/DataTable/DataTable.tsx
@@ -49,8 +49,9 @@ export const DataTable = <T,>({
         border: `1px solid ${surfaceColors.paperBorder}`,
         borderRadius: '0.75rem',
         boxShadow: 'none',
-        // overflow:hidden corta linhas extras dentro de flex/layout com altura limitada.
-        overflow: 'visible',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
         minWidth: 0,
         width: '100%',
         ...sx,
@@ -82,8 +83,9 @@ export const DataTable = <T,>({
       ) : null}
       <TableContainer
         sx={{
+          flex: 1,
           overflowX: 'auto',
-          overflowY: 'visible',
+          overflowY: 'auto',
           maxWidth: '100%',
         }}
       >

--- a/src/pages/CompaniesPage/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage/CompaniesPage.tsx
@@ -157,7 +157,7 @@ export const CompaniesPage = (): JSX.Element => {
         open={openAddModal}
         handleClose={() => setOpenAddModal(false)}
       />
-      <Stack spacing="2.5rem">
+      <Stack spacing="2.5rem" sx={{ height: '100%' }}>
         <Box
           display="flex"
           alignItems="flex-start"
@@ -205,7 +205,11 @@ export const CompaniesPage = (): JSX.Element => {
           columns={columns}
           getRowId={(row: CompanyWithStats) => row.id}
           loading={isLoading}
-          sx={{ border: `1px solid ${palette.neutrals[200]}` }}
+          sx={{
+            border: `1px solid ${palette.neutrals[200]}`,
+            flex: 1,
+            minHeight: 0,
+          }}
           onDetailsClick={(rowId) => {
             navigate({
               to: EPageRoutes.COMPANY_DETAIL,

--- a/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationEdit/ManagerInformationEdit.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationEdit/ManagerInformationEdit.tsx
@@ -71,7 +71,6 @@ export const ManagerInformationEdit = ({
                 : ''
             }
           >
-            <MenuItem value="">Selecione uma empresa</MenuItem>
             {companyOptions.map((option) => (
               <MenuItem key={option.id} value={option.id}>
                 {option.name}

--- a/src/pages/ManagersPage/ManagersPage.tsx
+++ b/src/pages/ManagersPage/ManagersPage.tsx
@@ -104,7 +104,7 @@ export const ManagersPage = (): JSX.Element => {
 
   return (
     <PageContainter>
-      <Stack spacing="2.5rem">
+      <Stack spacing="2.5rem" sx={{ height: '100%' }}>
         <Box
           display="flex"
           alignItems="flex-start"
@@ -145,7 +145,11 @@ export const ManagersPage = (): JSX.Element => {
           columns={columns}
           getRowId={(row: TManager) => row.id}
           loading={isLoading}
-          sx={{ border: `1px solid ${palette.neutrals[200]}` }}
+          sx={{
+            border: `1px solid ${palette.neutrals[200]}`,
+            flex: 1,
+            minHeight: 0,
+          }}
           onDetailsClick={(rowId) => {
             navigate({
               to: EPageRoutes.MANAGER_DETAIL,

--- a/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
+++ b/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
@@ -141,7 +141,7 @@ export const AdminMeetingsPage = (): JSX.Element => {
 
   return (
     <PageContainter>
-      <Stack spacing="2.5rem">
+      <Stack spacing="2.5rem" sx={{ height: '100%' }}>
         <PageHeader
           title={EPageTitles.MEETINGS}
           subtitle="Gerencie todas reuniões da plataforma"
@@ -183,7 +183,11 @@ export const AdminMeetingsPage = (): JSX.Element => {
           columns={columns}
           getRowId={(row: TMeetingListItem) => row.id}
           loading={isLoading}
-          sx={{ border: `1px solid ${palette.neutrals[200]}` }}
+          sx={{
+            border: `1px solid ${palette.neutrals[200]}`,
+            flex: 1,
+            minHeight: 0,
+          }}
           onDetailsClick={(rowId) => {
             navigate({
               to: EPageRoutes.SALESMAN_MEETINGS_DETAIL,

--- a/src/pages/SalesmenPage/AdminSalesmenPage/AdminSalesmenPage.tsx
+++ b/src/pages/SalesmenPage/AdminSalesmenPage/AdminSalesmenPage.tsx
@@ -67,7 +67,7 @@ export const AdminSalesmenPage = (): JSX.Element => {
 
   return (
     <PageContainter>
-      <Stack spacing="2.5rem">
+      <Stack spacing="2.5rem" sx={{ height: '100%' }}>
         <Box
           display="flex"
           alignItems="flex-start"
@@ -116,7 +116,11 @@ export const AdminSalesmenPage = (): JSX.Element => {
           columns={columns}
           getRowId={(row: TSalesmanWithCompany) => row.id}
           loading={isLoading}
-          sx={{ border: `1px solid ${palette.neutrals[200]}` }}
+          sx={{
+            border: `1px solid ${palette.neutrals[200]}`,
+            flex: 1,
+            minHeight: 0,
+          }}
           onDetailsClick={(rowId) => {
             navigate({
               to: EPageRoutes.SALESMAN_DETAIL,

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -1,10 +1,12 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { EPageTitles } from '@data/enums/EPageTitles';
+import { getSentimentConfig } from '@hooks/useSentiment';
 import { ArrowBack, Close, Save } from '@mui/icons-material';
 import {
   Box,
   Button,
   Link as MuiLink,
+  Stack,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -18,6 +20,7 @@ import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import { type JSX, useState } from 'react';
 
+import { formatAverageSentiment } from '../AdminSalesmenPage/salesmenColumns';
 import { SalesmanInformationEdit } from './SalesmanInformationEdit/SalesmanInformationEdit';
 import { SalesmanInformationView } from './SalesmanInformationView/SalesmanInformationView';
 
@@ -60,6 +63,17 @@ export const SalesmanDetail = (): JSX.Element => {
     return <PageNotFound />;
   }
 
+  const sentimentValue = salesman.average_sentiment ?? undefined;
+  const sentimentConfig = getSentimentConfig(sentimentValue);
+  const sentimentColorMap: Record<string, string> = {
+    success: palette.success[300],
+    warning: palette.warning[400],
+    error: palette.error[300],
+    neutrals: palette.neutrals[500],
+  };
+  const sentimentColor =
+    sentimentColorMap[sentimentConfig.theme] ?? palette.neutrals[500];
+
   return (
     <PageContainter>
       <Box
@@ -92,6 +106,23 @@ export const SalesmanDetail = (): JSX.Element => {
           <IconBox iconName="salesman" theme="salesmen" />
           <PageHeader title={salesman.name} subtitle="" />
         </Box>
+
+        <Stack
+          direction="row"
+          justifyContent="flex-end"
+          alignItems="center"
+          spacing="0.75rem"
+        >
+          <IconBox
+            iconName={sentimentConfig.iconName}
+            theme={sentimentConfig.theme}
+          />
+          <Typography fontWeight={600} fontSize="1.5rem" color={sentimentColor}>
+            {typeof sentimentValue === 'number'
+              ? formatAverageSentiment(sentimentValue)
+              : '-'}
+          </Typography>
+        </Stack>
 
         <EntityDetailsCard
           title={EPageTitles.SALESMAN_INFORMATION}

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
@@ -65,7 +65,6 @@ export const SalesmanInformationEdit = ({
             onChange={(e) => onFieldChange('companyId', e.target.value)}
             fullWidth
           >
-            <MenuItem value="">Selecione uma empresa</MenuItem>
             {companyOptions.map((option) => (
               <MenuItem key={option.id} value={option.id}>
                 {option.name}

--- a/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetail.tsx
+++ b/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetail.tsx
@@ -83,7 +83,7 @@ export const MeetingDetail = (): JSX.Element => {
 
   return (
     <PageContainter>
-      <Stack spacing={3} sx={{ width: '100%', alignSelf: 'flex-start' }}>
+      <Stack spacing={3} sx={{ width: '100%', height: '100%' }}>
         <MeetingDetailHeaderStats
           meeting={meeting}
           palette={palette}
@@ -91,13 +91,22 @@ export const MeetingDetail = (): JSX.Element => {
           responsiveValueFontSize={responsiveValueFontSize}
         />
 
-        <MeetingDetailTabsContent
-          meeting={meeting}
-          meetingPostAnalysis={meetingPostAnalysis || null}
-          isMeetingPostAnalysisLoading={isMeetingPostAnalysisLoading}
-          currentTab={currentTab}
-          onTabChange={handleTabChange}
-        />
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <MeetingDetailTabsContent
+            meeting={meeting}
+            meetingPostAnalysis={meetingPostAnalysis || null}
+            isMeetingPostAnalysisLoading={isMeetingPostAnalysisLoading}
+            currentTab={currentTab}
+            onTabChange={handleTabChange}
+          />
+        </Box>
       </Stack>
     </PageContainter>
   );

--- a/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailTabsContent/MeetingDetailTabsContent.tsx
+++ b/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailTabsContent/MeetingDetailTabsContent.tsx
@@ -39,6 +39,9 @@ export const MeetingDetailTabsContent = ({
         border: '1px solid',
         borderColor: 'divider',
         overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
       }}
     >
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -64,7 +67,7 @@ export const MeetingDetailTabsContent = ({
         </Tabs>
       </Box>
 
-      <Box minHeight="300px">
+      <Box sx={{ flex: 1, overflow: 'auto' }}>
         {currentTab === 'context' && (
           <MeetingContext
             meeting={meeting}


### PR DESCRIPTION
## Issue relacionada
no-ref

## O que foi implementado?

- **Remoção do Select Placeholder:** Removida a opção vazia (`<MenuItem value="">Selecione uma empresa</MenuItem>`) dos seletores de empresas nos formulários de edição de Gerentes (`ManagerInformationEdit`) e Vendedores (`SalesmanInformationEdit`).
- **Ajustes de Layout :**
- Scroll apenas nas tabelas, agora cards e headers ficam fixos na tela
- remoção da opção "Selecionar empresa" no selector de empresas
- Card de reuniões agora ocupa o espaçamento correto

## Por que essa mudança é necessária?

- As opções de estado inicial vazias no componente Select estavam gerando comportamentos não intencionais de seleção. A limpeza as torna mais previsíveis.
- Havia problemas de overflow nas páginas de listagem/tabelas e em modais com abas de detalhes de reuniões.

## Como testar?

1. Edite as informações de um gerente/vendedor e verifique se o dropdown de empresas exibe apenas opções válidas e funciona de forma adequada.
2. Acesse as páginas de Empresas, Gerentes, Representantes e Reuniões para checar se o `DataTable` se expande e cria o scroll interno quando necessário, em diferentes resoluções, sem quebrar os containers.
3. Acesse a página de detalhes da reunião e navegue nas tabs para validar se o container exibe o conteúdo adequadamente ocupando 100% da altura disponível

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [ ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças