### PR TITLE
Feat/32/company select with only active companies

### DIFF
--- a/src/pages/ManagersPage/AddManagerModal/AddManagerModal.tsx
+++ b/src/pages/ManagersPage/AddManagerModal/AddManagerModal.tsx
@@ -43,7 +43,9 @@ export const AddManagerModal = ({
   });
 
   const { data: companiesPage } = useGetCompanies();
-  const companyOptions: TCompany[] = companiesPage?.content ?? [];
+  const companyOptions: TCompany[] = (companiesPage?.content ?? []).filter(
+    (c) => c.active
+  );
 
   useEffect(() => {
     if (!open) {

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
@@ -43,7 +43,9 @@ export const AddSalesmanModal = ({
   });
 
   const { data: companiesPage } = useGetCompanies();
-  const companyOptions: TCompany[] = companiesPage?.content ?? [];
+  const companyOptions: TCompany[] = (companiesPage?.content ?? []).filter(
+    (c) => c.active
+  );
 
   useEffect(() => {
     if (!open) {


### PR DESCRIPTION
## Issue relacionada

https://github.com/orgs/SalesPilot-AGES/projects/2/views/1?pane=issue&itemId=184837166&issue=SalesPilot-AGES%7CFrontend%7C32

## O que foi implementado?

Filtragem de dados nos select de empresa nos modais de criar gestor e criar vendedor, para aparecer apenas empresas ativas.

## Por que essa mudança é necessária?

Para que só se possa criar vendedores e gestores em empresas ativas do sistema, visto que empresas inativas estão sem plano ativo e teoricamente por isso não tem mais acesso ao sistema.

## Como testar?

Rodar o projeto -> entrar na tela de listagem de gestores -> clicar em adicionar gestor -> ver se na lista do select de empresas não tem nenhuma empresa inativa

Rodar o projeto -> entrar na tela de listagem de vendedores-> clicar em adicionar vendedor -> ver se na lista do select de empresas não tem nenhuma empresa inativa

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças
