### PR TITLE
Feat/no ref/discord pr pipeline

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -25,6 +25,9 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           EVENT="${{ github.event_name }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -34,7 +37,7 @@ jobs:
             ASSIGNEES=$(echo '${{ toJson(github.event.pull_request.assignees) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
             REVIEWERS=$(echo '${{ toJson(github.event.pull_request.requested_reviewers) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
 
-            BODY="${{ github.event.pull_request.body }}"
+            BODY="$PR_BODY"
             if [ -z "$BODY" ]; then BODY="Sem descrição."; fi
             TRUNCATED_BODY=$(echo "$BODY" | cut -c1-1000)
             if [ $(echo "$BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
@@ -109,10 +112,10 @@ jobs:
               EMBED_TITLE="Review: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
-              REVIEW_BODY="${{ github.event.review.body }}"
-              if [ -z "$REVIEW_BODY" ]; then REVIEW_BODY="Sem comentário."; fi
-              TRUNCATED_BODY=$(echo "$REVIEW_BODY" | cut -c1-1000)
-              if [ $(echo "$REVIEW_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+              REVIEW_BODY_TEXT="$REVIEW_BODY"
+              if [ -z "$REVIEW_BODY_TEXT" ]; then REVIEW_BODY_TEXT="Sem comentário."; fi
+              TRUNCATED_BODY=$(echo "$REVIEW_BODY_TEXT" | cut -c1-1000)
+              if [ $(echo "$REVIEW_BODY_TEXT" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
 
               PAYLOAD=$(jq -n \
                 --arg title "$EMBED_TITLE" \
@@ -139,7 +142,6 @@ jobs:
               EMBED_TITLE="Comentário: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
               EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
 
-              COMMENT_BODY="${{ github.event.comment.body }}"
               TRUNCATED_BODY=$(echo "$COMMENT_BODY" | cut -c1-1000)
               if [ $(echo "$COMMENT_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
 

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -1,0 +1,170 @@
+name: Discord Notification
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches:
+      - main
+      - development
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      github.event_name == 'pull_request_review' ||
+      github.event_name == 'pull_request_review_comment'
+    steps:
+      - name: Send notification to Discord Forum
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EVENT="${{ github.event_name }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # ── PR aberto: cria o tópico e armazena o thread ID ──────────────
+          if [ "$EVENT" = "pull_request" ]; then
+            ASSIGNEES=$(echo '${{ toJson(github.event.pull_request.assignees) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
+            REVIEWERS=$(echo '${{ toJson(github.event.pull_request.requested_reviewers) }}' | jq -r '[.[].login] | if length == 0 then "Nenhum" else join(", ") end')
+
+            BODY="${{ github.event.pull_request.body }}"
+            if [ -z "$BODY" ]; then BODY="Sem descrição."; fi
+            TRUNCATED_BODY=$(echo "$BODY" | cut -c1-1000)
+            if [ $(echo "$BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+
+            THREAD_NAME="PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
+            THREAD_NAME=$(echo "$THREAD_NAME" | cut -c1-100)
+
+            PAYLOAD=$(jq -n \
+              --arg thread_name "$THREAD_NAME" \
+              --arg pr_url "${{ github.event.pull_request.html_url }}" \
+              --arg author "${{ github.event.pull_request.user.login }}" \
+              --arg base "${{ github.event.pull_request.base.ref }}" \
+              --arg head "${{ github.event.pull_request.head.ref }}" \
+              --arg assignees "$ASSIGNEES" \
+              --arg reviewers "$REVIEWERS" \
+              --arg body "$TRUNCATED_BODY" \
+              '{
+                thread_name: $thread_name,
+                embeds: [{
+                  title: $thread_name,
+                  url: $pr_url,
+                  color: 5814783,
+                  fields: [
+                    { name: "Autor",     value: $author,                                inline: true },
+                    { name: "Branch",    value: ("`" + $head + "` → `" + $base + "`"), inline: true },
+                    { name: "Assignees", value: $assignees,                             inline: true },
+                    { name: "Reviewers", value: $reviewers,                             inline: true },
+                    { name: "Descrição", value: $body,                                  inline: false }
+                  ],
+                  footer: { text: "SalesPilot Frontend" }
+                }]
+              }')
+
+            # ?wait=true faz o Discord retornar o objeto da mensagem criada
+            RESPONSE=$(curl -s \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "${DISCORD_WEBHOOK_URL}?wait=true")
+            echo "$RESPONSE"
+
+            # channel_id no contexto de fórum é o ID do tópico criado
+            THREAD_ID=$(echo "$RESPONSE" | jq -r '.channel_id // empty')
+            if [ -n "$THREAD_ID" ]; then
+              gh pr comment "$PR_NUMBER" \
+                --repo "${{ github.repository }}" \
+                --body "<!-- discord-thread-id: ${THREAD_ID} -->"
+            fi
+
+          # ── Review / Comentário: posta dentro do tópico existente ─────────
+          else
+            THREAD_ID=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json comments \
+              --jq '.comments[].body' 2>/dev/null \
+              | grep -oE 'discord-thread-id: [0-9]+' \
+              | grep -oE '[0-9]+$' \
+              | head -1)
+
+            if [ -z "$THREAD_ID" ]; then
+              echo "Thread ID não encontrado para PR #${PR_NUMBER}, notificação ignorada."
+              exit 0
+            fi
+
+            if [ "$EVENT" = "pull_request_review" ]; then
+              REVIEW_STATE="${{ github.event.review.state }}"
+              case "$REVIEW_STATE" in
+                approved)          STATE_LABEL="Aprovado ✅";             COLOR=3066993  ;;
+                changes_requested) STATE_LABEL="Mudanças Solicitadas ❌"; COLOR=15158332 ;;
+                *)                 STATE_LABEL="Comentado 💬";            COLOR=16776960 ;;
+              esac
+
+              EMBED_TITLE="Review: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
+              EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
+
+              REVIEW_BODY="${{ github.event.review.body }}"
+              if [ -z "$REVIEW_BODY" ]; then REVIEW_BODY="Sem comentário."; fi
+              TRUNCATED_BODY=$(echo "$REVIEW_BODY" | cut -c1-1000)
+              if [ $(echo "$REVIEW_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+
+              PAYLOAD=$(jq -n \
+                --arg title "$EMBED_TITLE" \
+                --arg review_url "${{ github.event.review.html_url }}" \
+                --arg reviewer "${{ github.event.review.user.login }}" \
+                --arg state_label "$STATE_LABEL" \
+                --arg body "$TRUNCATED_BODY" \
+                --argjson color "$COLOR" \
+                '{
+                  embeds: [{
+                    title: $title,
+                    url: $review_url,
+                    color: $color,
+                    fields: [
+                      { name: "Revisor", value: $reviewer,    inline: true },
+                      { name: "Status",  value: $state_label, inline: true },
+                      { name: "Comentário", value: $body,     inline: false }
+                    ],
+                    footer: { text: "SalesPilot Frontend" }
+                  }]
+                }')
+
+            elif [ "$EVENT" = "pull_request_review_comment" ]; then
+              EMBED_TITLE="Comentário: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
+              EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
+
+              COMMENT_BODY="${{ github.event.comment.body }}"
+              TRUNCATED_BODY=$(echo "$COMMENT_BODY" | cut -c1-1000)
+              if [ $(echo "$COMMENT_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+
+              PAYLOAD=$(jq -n \
+                --arg title "$EMBED_TITLE" \
+                --arg comment_url "${{ github.event.comment.html_url }}" \
+                --arg commenter "${{ github.event.comment.user.login }}" \
+                --arg body "$TRUNCATED_BODY" \
+                '{
+                  embeds: [{
+                    title: $title,
+                    url: $comment_url,
+                    color: 3447003,
+                    fields: [
+                      { name: "Autor",      value: $commenter, inline: true },
+                      { name: "Comentário", value: $body,      inline: false }
+                    ],
+                    footer: { text: "SalesPilot Frontend" }
+                  }]
+                }')
+            fi
+
+            RESPONSE=$(curl -s -w "\nHTTP_%{http_code}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "${DISCORD_WEBHOOK_URL}?thread_id=${THREAD_ID}")
+            echo "$RESPONSE"
+          fi

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -72,11 +72,18 @@ jobs:
               }')
 
             # ?wait=true faz o Discord retornar o objeto da mensagem criada
-            RESPONSE=$(curl -s \
+            HTTP_CODE=$(curl -s -o /tmp/discord_response \
+              -w "%{http_code}" \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "${DISCORD_WEBHOOK_URL}?wait=true")
-            echo "$RESPONSE"
+            RESPONSE=$(cat /tmp/discord_response)
+            echo "HTTP ${HTTP_CODE}: ${RESPONSE}"
+
+            if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then
+              echo "Discord webhook failed with HTTP ${HTTP_CODE}."
+              exit 1
+            fi
 
             # channel_id no contexto de fórum é o ID do tópico criado
             THREAD_ID=$(echo "$RESPONSE" | jq -r '.channel_id // empty')
@@ -84,6 +91,8 @@ jobs:
               gh pr comment "$PR_NUMBER" \
                 --repo "${{ github.repository }}" \
                 --body "<!-- discord-thread-id: ${THREAD_ID} -->"
+            else
+              echo "Warning: channel_id not found in response. Is DISCORD_WEBHOOK_URL a Forum channel webhook?"
             fi
 
           # ── Review / Comentário: posta dentro do tópico existente ─────────

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -39,11 +39,11 @@ jobs:
 
             BODY="$PR_BODY"
             if [ -z "$BODY" ]; then BODY="Sem descrição."; fi
-            TRUNCATED_BODY=$(echo "$BODY" | cut -c1-1000)
-            if [ $(echo "$BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+            TRUNCATED_BODY="${BODY:0:1000}"
+            [ "${#BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
             THREAD_NAME="PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
-            THREAD_NAME=$(echo "$THREAD_NAME" | cut -c1-100)
+            THREAD_NAME="${THREAD_NAME:0:100}"
 
             PAYLOAD=$(jq -n \
               --arg thread_name "$THREAD_NAME" \
@@ -119,12 +119,11 @@ jobs:
               esac
 
               EMBED_TITLE="Review: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
-              EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
+              EMBED_TITLE="${EMBED_TITLE:0:256}"
 
-              REVIEW_BODY_TEXT="$REVIEW_BODY"
-              if [ -z "$REVIEW_BODY_TEXT" ]; then REVIEW_BODY_TEXT="Sem comentário."; fi
-              TRUNCATED_BODY=$(echo "$REVIEW_BODY_TEXT" | cut -c1-1000)
-              if [ $(echo "$REVIEW_BODY_TEXT" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+              if [ -z "$REVIEW_BODY" ]; then REVIEW_BODY="Sem comentário."; fi
+              TRUNCATED_BODY="${REVIEW_BODY:0:1000}"
+              [ "${#REVIEW_BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
               PAYLOAD=$(jq -n \
                 --arg title "$EMBED_TITLE" \
@@ -149,10 +148,10 @@ jobs:
 
             elif [ "$EVENT" = "pull_request_review_comment" ]; then
               EMBED_TITLE="Comentário: PR #${PR_NUMBER} — ${{ github.event.pull_request.title }}"
-              EMBED_TITLE=$(echo "$EMBED_TITLE" | cut -c1-256)
+              EMBED_TITLE="${EMBED_TITLE:0:256}"
 
-              TRUNCATED_BODY=$(echo "$COMMENT_BODY" | cut -c1-1000)
-              if [ $(echo "$COMMENT_BODY" | wc -m) -gt 1000 ]; then TRUNCATED_BODY="${TRUNCATED_BODY}..."; fi
+              TRUNCATED_BODY="${COMMENT_BODY:0:1000}"
+              [ "${#COMMENT_BODY}" -gt 1000 ] && TRUNCATED_BODY="${TRUNCATED_BODY}..."
 
               PAYLOAD=$(jq -n \
                 --arg title "$EMBED_TITLE" \


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->

## O que foi implementado?

Adição do workflow `discord-pr-notify.yml` no repositório do frontend, adaptado a partir do workflow equivalente do backend.

O workflow envia notificações automáticas para um canal de fórum no Discord em três situações:
- Abertura de Pull Request (cria um novo tópico no fórum)
- Submissão de review (posta dentro do tópico existente)
- Comentário de review (posta dentro do tópico existente)

A única diferença em relação ao backend é o rodapé dos embeds, identificado como `"SalesPilot Frontend"`.

## Por que essa mudança é necessária?

Manter a paridade de observabilidade entre os repositórios de backend e frontend. Com o workflow, o time é notificado no Discord sempre que há movimentação em PRs do frontend, da mesma forma que já ocorre no backend.

## Como testar?

1. Abrir um Pull Request não-draft nas branches `main` ou `development` do repositório frontend
2. Verificar se um novo tópico é criado no canal de fórum do Discord com as informações do PR
3. Submeter um review no PR e verificar se a notificação é postada dentro do tópico criado
4. Adicionar um comentário de review e verificar o mesmo comportamento

## Checklist

- [ ] O código foi revisado pelo próprio autor antes de abrir o MR
- [ ] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças