### PR TITLE
fix: reduce Vitest EMFILE issues with direct MUI icon imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
+    "@mui/x-charts": "^9.2.0",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-router": "^1.168.10",
     "@types/lodash": "^4.17.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@mui/material':
         specifier: ^7.3.9
         version: 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mui/x-charts':
+        specifier: ^9.2.0
+        version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.96.1
         version: 5.96.1(react@19.2.4)
@@ -486,6 +489,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@9.0.0':
+    resolution: {integrity: sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/utils@7.3.9':
     resolution: {integrity: sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==}
     engines: {node: '>=14.0.0'}
@@ -495,6 +506,54 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@mui/utils@9.0.0':
+    resolution: {integrity: sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@9.0.1':
+    resolution: {integrity: sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/x-charts-vendor@9.0.0':
+    resolution: {integrity: sha512-Do91i+fZiNj/4LN5oaGpJoutolzDBDwdfw6tHrx2LKXDMCRlaImCfreLbdbkk7dFsi9fuIP7hWiMV4vDJKPJTA==}
+
+  '@mui/x-charts@9.2.0':
+    resolution: {integrity: sha512-lI4E/o31g6x4daS6JkYVHmJRNW+/3IF4cWMuTxDEx9fVTOGJszLOwRqUxbw6oZl850HRedcCiOmREPsUcWHwhw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^7.3.0 || ^9.0.0
+      '@mui/system': ^7.3.0 || ^9.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-internal-gestures@9.2.0':
+    resolution: {integrity: sha512-VQ+2mFskgAhCyuIrbkp6//eSwvGiHMurv0yIU+cztMHAHhbkwQSxq3dJDzcAjWawy7e//6TocIYaHL9PFK1vVg==}
+
+  '@mui/x-internals@9.1.0':
+    resolution: {integrity: sha512-fVezTa1lU+Hb3y9UMI8D/iWXADhs0I8PaZqoh2LOUXjGEUJmKqwsRD19ZXInZsH2yu+YS0dqYMPDvzjYTTyo+Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -685,6 +744,36 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -899,6 +988,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bezier-easing@2.1.0:
+    resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -981,6 +1073,46 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -1168,6 +1300,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatqueue@3.0.0:
+    resolution: {integrity: sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -1271,6 +1406,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1704,6 +1843,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2487,6 +2629,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@mui/types@9.0.0(@types/react@19.2.14)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@mui/utils@7.3.9(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -2498,6 +2646,92 @@ snapshots:
       react-is: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@mui/utils@9.0.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/types': 9.0.0(@types/react@19.2.14)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-is: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/utils@9.0.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/types': 9.0.0(@types/react@19.2.14)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-is: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/x-charts-vendor@9.0.0':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/d3-array': 3.2.2
+      '@types/d3-color': 3.1.3
+      '@types/d3-format': 3.0.4
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-color: 3.1.0
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      flatqueue: 3.0.0
+      internmap: 2.0.3
+
+  '@mui/x-charts@9.2.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/material': 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mui/system': 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      '@mui/utils': 9.0.1(@types/react@19.2.14)(react@19.2.4)
+      '@mui/x-charts-vendor': 9.0.0
+      '@mui/x-internal-gestures': 9.2.0
+      '@mui/x-internals': 9.1.0(@types/react@19.2.14)(react@19.2.4)
+      bezier-easing: 2.1.0
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internal-gestures@9.2.0':
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  '@mui/x-internals@9.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/utils': 9.0.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -2646,6 +2880,32 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2896,6 +3156,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.11: {}
 
+  bezier-easing@2.1.0: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -2979,6 +3241,42 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -3166,6 +3464,8 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flatqueue@3.0.0: {}
+
   flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
@@ -3255,6 +3555,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  internmap@2.0.3: {}
 
   is-arrayish@0.2.1: {}
 
@@ -3621,6 +3923,8 @@ snapshots:
       strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/UI/EntityDetailsCard/EntityDetailsCard.tsx
+++ b/src/UI/EntityDetailsCard/EntityDetailsCard.tsx
@@ -1,4 +1,4 @@
-import { Edit } from '@mui/icons-material';
+import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import type { JSX, ReactNode } from 'react';
 
@@ -45,7 +45,11 @@ export const EntityDetailsCard = ({
 
         {headerRight ??
           (onEdit && (
-            <Button variant="contained" startIcon={<Edit />} onClick={onEdit}>
+            <Button
+              variant="contained"
+              startIcon={<EditIcon />}
+              onClick={onEdit}
+            >
               Editar
             </Button>
           ))}

--- a/src/apis/dashboardApi.ts
+++ b/src/apis/dashboardApi.ts
@@ -1,0 +1,63 @@
+import apiClient from '@services/api/apiClient';
+import { z } from 'zod';
+
+const DashboardAvgDurationPointSchema = z.object({
+  month: z.string(),
+  month_label: z.string(),
+  avg_minutes: z.number(),
+});
+
+const DashboardAvgDurationResponseSchema = z.object({
+  data: z.array(DashboardAvgDurationPointSchema),
+});
+
+type TDashboardAvgDurationApiPoint = z.infer<
+  typeof DashboardAvgDurationPointSchema
+>;
+
+export type TDashboardAvgDurationPoint = {
+  month: string;
+  monthLabel: string;
+  avgMinutes: number;
+};
+
+export const mockAvgDurationData = [
+  { month: '2024-01-01T00:00:00Z', month_label: 'Jan', avg_minutes: 38 },
+  { month: '2024-02-01T00:00:00Z', month_label: 'Fev', avg_minutes: 41 },
+  { month: '2024-03-01T00:00:00Z', month_label: 'Mar', avg_minutes: 39 },
+  { month: '2024-04-01T00:00:00Z', month_label: 'Abr', avg_minutes: 42 },
+  { month: '2024-05-01T00:00:00Z', month_label: 'Mai', avg_minutes: 40 },
+  { month: '2024-06-01T00:00:00Z', month_label: 'Jun', avg_minutes: 43 },
+];
+const USE_MOCK_AVG_DURATION_DATA = import.meta.env.DEV;
+// Mock temporario ate o backend disponibilizar GET /api/dashboard/avg-duration.
+
+const mapAvgDurationPoint = (
+  point: TDashboardAvgDurationApiPoint
+): TDashboardAvgDurationPoint => {
+  return {
+    month: point.month,
+    monthLabel: point.month_label,
+    avgMinutes: point.avg_minutes,
+  };
+};
+
+export const dashboardApi = {
+  getAvgDuration: async (): Promise<TDashboardAvgDurationPoint[]> => {
+    if (USE_MOCK_AVG_DURATION_DATA) {
+      const parsedMockResponse = DashboardAvgDurationResponseSchema.parse({
+        data: mockAvgDurationData,
+      });
+      return parsedMockResponse.data.map(mapAvgDurationPoint);
+    }
+
+    const response = await apiClient.get<unknown>(
+      '/api/dashboard/avg-duration'
+    );
+
+    const parsedResponse = DashboardAvgDurationResponseSchema.parse(
+      response.data
+    );
+    return parsedResponse.data.map(mapAvgDurationPoint);
+  },
+};

--- a/src/apis/dashboardApi.ts
+++ b/src/apis/dashboardApi.ts
@@ -1,3 +1,4 @@
+import { mockDashboardAvgDurationData } from '@data/mocks/DashboardAvgDuration';
 import apiClient from '@services/api/apiClient';
 import { z } from 'zod';
 
@@ -21,14 +22,6 @@ export type TDashboardAvgDurationPoint = {
   avgMinutes: number;
 };
 
-export const mockAvgDurationData = [
-  { month: '2024-01-01T00:00:00Z', month_label: 'Jan', avg_minutes: 38 },
-  { month: '2024-02-01T00:00:00Z', month_label: 'Fev', avg_minutes: 41 },
-  { month: '2024-03-01T00:00:00Z', month_label: 'Mar', avg_minutes: 39 },
-  { month: '2024-04-01T00:00:00Z', month_label: 'Abr', avg_minutes: 42 },
-  { month: '2024-05-01T00:00:00Z', month_label: 'Mai', avg_minutes: 40 },
-  { month: '2024-06-01T00:00:00Z', month_label: 'Jun', avg_minutes: 43 },
-];
 const USE_MOCK_AVG_DURATION_DATA = import.meta.env.DEV;
 // Mock temporario ate o backend disponibilizar GET /api/dashboard/avg-duration.
 
@@ -46,7 +39,7 @@ export const dashboardApi = {
   getAvgDuration: async (): Promise<TDashboardAvgDurationPoint[]> => {
     if (USE_MOCK_AVG_DURATION_DATA) {
       const parsedMockResponse = DashboardAvgDurationResponseSchema.parse({
-        data: mockAvgDurationData,
+        data: mockDashboardAvgDurationData,
       });
       return parsedMockResponse.data.map(mapAvgDurationPoint);
     }

--- a/src/data/enums/EAvgDurationLineChart.ts
+++ b/src/data/enums/EAvgDurationLineChart.ts
@@ -1,0 +1,7 @@
+export const EAvgDurationLineChart = {
+  ERROR_TITLE: 'Não foi possível carregar o gráfico',
+  ERROR_DESCRIPTION: 'Tente novamente em instantes.',
+  EMPTY_TITLE: 'Sem dados de duração média no momento',
+  EMPTY_DESCRIPTION:
+    'Assim que houver reuniões consolidadas, o gráfico será exibido aqui.',
+};

--- a/src/data/mocks/DashboardAvgDuration.ts
+++ b/src/data/mocks/DashboardAvgDuration.ts
@@ -1,0 +1,8 @@
+export const mockDashboardAvgDurationData = [
+  { month: '2024-01-01T00:00:00Z', month_label: 'Jan', avg_minutes: 38 },
+  { month: '2024-02-01T00:00:00Z', month_label: 'Fev', avg_minutes: 41 },
+  { month: '2024-03-01T00:00:00Z', month_label: 'Mar', avg_minutes: 39 },
+  { month: '2024-04-01T00:00:00Z', month_label: 'Abr', avg_minutes: 42 },
+  { month: '2024-05-01T00:00:00Z', month_label: 'Mai', avg_minutes: 40 },
+  { month: '2024-06-01T00:00:00Z', month_label: 'Jun', avg_minutes: 43 },
+];

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
@@ -1,7 +1,7 @@
 import { ECardLabel } from '@data/enums/ECardLabel';
 import { EPageRoutes } from '@data/enums/EPageRoutes';
-import { ArrowBack } from '@mui/icons-material';
 import ApartmentOutlinedIcon from '@mui/icons-material/ApartmentOutlined';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import {
   IconButton,
   Link as MuiLink,
@@ -68,7 +68,7 @@ export const CompanyDetail = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para empresas
         </MuiLink>
 

--- a/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
@@ -1,5 +1,7 @@
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
+import { Stack } from '@mui/material';
+import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import type { JSX } from 'react';
@@ -7,10 +9,13 @@ import type { JSX } from 'react';
 export const AdminDashboard = (): JSX.Element => {
   return (
     <PageContainter>
-      <PageHeader
-        title={EPageTitles.ADMIN_DASHBOARD}
-        subtitle={EpageDescriptions.ADMIN_DASHBOARD}
-      />
+      <Stack spacing={4} sx={{ width: '100%' }}>
+        <PageHeader
+          title={EPageTitles.ADMIN_DASHBOARD}
+          subtitle={EpageDescriptions.ADMIN_DASHBOARD}
+        />
+        <AvgDurationLineChart />
+      </Stack>
     </PageContainter>
   );
 };

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 
 export const DashboardPage = (): JSX.Element => {
   const role = useCurrentUserRole();
+
   if (role === 'admin') return <AdminDashboard />;
   if (role === 'manager') return <ManagerDashboard />;
   return <SalesmanDashboard />;

--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
@@ -1,5 +1,7 @@
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
+import { Stack } from '@mui/material';
+import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import type { JSX } from 'react';
@@ -7,10 +9,13 @@ import type { JSX } from 'react';
 export const ManagerDashboard = (): JSX.Element => {
   return (
     <PageContainter>
-      <PageHeader
-        title={EPageTitles.MANAGER_DASHBOARD}
-        subtitle={EpageDescriptions.MANAGER_DASHBOARD}
-      />
+      <Stack spacing={4} sx={{ width: '100%' }}>
+        <PageHeader
+          title={EPageTitles.MANAGER_DASHBOARD}
+          subtitle={EpageDescriptions.MANAGER_DASHBOARD}
+        />
+        <AvgDurationLineChart />
+      </Stack>
     </PageContainter>
   );
 };

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
@@ -1,5 +1,7 @@
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
+import { Stack } from '@mui/material';
+import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import type { JSX } from 'react';
@@ -7,10 +9,13 @@ import type { JSX } from 'react';
 export const SalesmanDashboard = (): JSX.Element => {
   return (
     <PageContainter>
-      <PageHeader
-        title={EPageTitles.SALESMAN_DASHBOARD}
-        subtitle={EpageDescriptions.SALESMAN_DASHBOARD}
-      />
+      <Stack spacing={4} sx={{ width: '100%' }}>
+        <PageHeader
+          title={EPageTitles.SALESMAN_DASHBOARD}
+          subtitle={EpageDescriptions.SALESMAN_DASHBOARD}
+        />
+        <AvgDurationLineChart />
+      </Stack>
     </PageContainter>
   );
 };

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.style.ts
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.style.ts
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+export const StyledLineChart = styled(LineChart, {
+  shouldForwardProp: (prop) => prop !== 'lineColor',
+})<{ lineColor: string }>(({ lineColor }) => ({
+  '.MuiMarkElement-root': {
+    stroke: lineColor,
+    strokeWidth: 2,
+    fill: lineColor,
+  },
+  '.MuiMarkElement-root[data-highlighted="true"]': {
+    stroke: lineColor,
+    fill: lineColor,
+    strokeWidth: 3,
+  },
+}));

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
@@ -1,3 +1,5 @@
+import { EAvgDurationLineChart } from '@data/enums/EAvgDurationLineChart';
+import { ECardLabel } from '@data/enums/ECardLabel';
 import { render, screen } from '@tests/testUtils';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -51,7 +53,7 @@ describe('AvgDurationLineChart', () => {
     render(<AvgDurationLineChart />);
 
     expect(
-      screen.getByText('Sem dados de duração média no momento')
+      screen.getByText(EAvgDurationLineChart.EMPTY_TITLE)
     ).toBeInTheDocument();
   });
 
@@ -65,7 +67,7 @@ describe('AvgDurationLineChart', () => {
     render(<AvgDurationLineChart />);
 
     expect(
-      screen.getByText('Não foi possível carregar o gráfico')
+      screen.getByText(EAvgDurationLineChart.ERROR_TITLE)
     ).toBeInTheDocument();
   });
 
@@ -81,7 +83,9 @@ describe('AvgDurationLineChart', () => {
 
     render(<AvgDurationLineChart />);
 
-    expect(screen.getByText('Duração média das reuniões')).toBeInTheDocument();
+    expect(
+      screen.getByText(ECardLabel.AVERAGE_MEETINGS_DURATION)
+    ).toBeInTheDocument();
     expect(
       document.querySelector('[data-series-id="avg-duration"]')
     ).toBeTruthy();

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@tests/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AvgDurationLineChart } from './AvgDurationLineChart';
+import { formatDuration, formatMonthLabel } from './AvgDurationLineChart.utils';
+
+const mockUseDashboardAvgDuration = vi.fn();
+
+vi.mock('@store/hooks/useDashboardAvgDuration', () => ({
+  useDashboardAvgDuration: () => mockUseDashboardAvgDuration(),
+}));
+
+describe('AvgDurationLineChart', () => {
+  it('formats month labels to full month names in portuguese', () => {
+    expect(formatMonthLabel('Jan')).toBe('Janeiro');
+    expect(formatMonthLabel('Mai')).toBe('Maio');
+    expect(formatMonthLabel('Jun')).toBe('Junho');
+    expect(formatMonthLabel('Xyz')).toBe('Xyz');
+  });
+
+  it('formats durations with singular/plural and hour conversion', () => {
+    expect(formatDuration(1)).toBe('1 minuto');
+    expect(formatDuration(2)).toBe('2 minutos');
+    expect(formatDuration(60)).toBe('1 hora');
+    expect(formatDuration(61)).toBe('1 hora e 1 minuto');
+    expect(formatDuration(120)).toBe('2 horas');
+    expect(formatDuration(158)).toBe('2 horas e 38 minutos');
+    expect(formatDuration(38.4)).toBe('38 minutos');
+    expect(formatDuration(38.6)).toBe('39 minutos');
+  });
+
+  it('renders loading state', () => {
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<AvgDurationLineChart />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders empty state when there is no data', () => {
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<AvgDurationLineChart />);
+
+    expect(
+      screen.getByText('Sem dados de duração média no momento')
+    ).toBeInTheDocument();
+  });
+
+  it('renders error state when request fails', () => {
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<AvgDurationLineChart />);
+
+    expect(
+      screen.getByText('Não foi possível carregar o gráfico')
+    ).toBeInTheDocument();
+  });
+
+  it('renders chart with API data', () => {
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [
+        { month: '2024-05-01T00:00:00Z', monthLabel: 'Mai', avgMinutes: 42.5 },
+        { month: '2024-06-01T00:00:00Z', monthLabel: 'Jun', avgMinutes: 38.2 },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<AvgDurationLineChart />);
+
+    expect(screen.getByText('Duração média das reuniões')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-series-id="avg-duration"]')
+    ).toBeTruthy();
+  });
+});

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
@@ -1,0 +1,200 @@
+import ShowChartOutlinedIcon from '@mui/icons-material/ShowChartOutlined';
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Stack,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { useDashboardAvgDuration } from '@store/hooks/useDashboardAvgDuration';
+import type { JSX } from 'react';
+import { useMemo } from 'react';
+
+import { formatDuration, formatMonthLabel } from './AvgDurationLineChart.utils';
+
+type TChartYBounds = {
+  min: number;
+  max: number;
+};
+
+const resolveYBounds = (values: number[]): TChartYBounds => {
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+
+  if (minValue === maxValue) {
+    const padding = Math.max(1, minValue * 0.2);
+    return {
+      min: Math.max(0, Number((minValue - padding).toFixed(1))),
+      max: Number((maxValue + padding).toFixed(1)),
+    };
+  }
+
+  const range = maxValue - minValue;
+  const padding = range * 0.15;
+
+  return {
+    min: Math.max(0, Number((minValue - padding).toFixed(1))),
+    max: Number((maxValue + padding).toFixed(1)),
+  };
+};
+
+export const AvgDurationLineChart = (): JSX.Element => {
+  const { palette } = useTheme();
+  const { data = [], isLoading, isError } = useDashboardAvgDuration();
+
+  const chartData = useMemo(
+    () =>
+      data.map((point) => ({
+        monthLabel: point.monthLabel,
+        avgMinutes: Number(point.avgMinutes.toFixed(1)),
+      })),
+    [data]
+  );
+
+  const yBounds = useMemo<TChartYBounds>(() => {
+    if (chartData.length === 0) {
+      return { min: 0, max: 10 };
+    }
+
+    return resolveYBounds(chartData.map((point) => point.avgMinutes));
+  }, [chartData]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        border: `1px solid ${palette.neutrals[200]}`,
+        borderRadius: '1rem',
+      }}
+    >
+      <Stack spacing={2}>
+        <Stack spacing={0.5}>
+          <Typography variant="h4">Duração média das reuniões</Typography>
+        </Stack>
+
+        {isLoading ? (
+          <Box
+            sx={{
+              minHeight: '18rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <CircularProgress size={28} />
+          </Box>
+        ) : isError ? (
+          <Stack
+            spacing={1}
+            alignItems="center"
+            justifyContent="center"
+            sx={{ minHeight: '18rem' }}
+          >
+            <Typography variant="subtitle1" fontWeight={700}>
+              Não foi possível carregar o gráfico
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              textAlign="center"
+            >
+              Tente novamente em instantes.
+            </Typography>
+          </Stack>
+        ) : chartData.length === 0 ? (
+          <Stack
+            spacing={1}
+            alignItems="center"
+            justifyContent="center"
+            sx={{ minHeight: '18rem' }}
+          >
+            <Box
+              sx={{
+                backgroundColor: palette.primary[100],
+                color: palette.primary[500],
+                width: 56,
+                height: 56,
+                borderRadius: '999px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <ShowChartOutlinedIcon />
+            </Box>
+            <Typography variant="subtitle1" fontWeight={700}>
+              Sem dados de duração média no momento
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              textAlign="center"
+            >
+              Assim que houver reuniões consolidadas, o gráfico será exibido
+              aqui.
+            </Typography>
+          </Stack>
+        ) : (
+          <LineChart
+            height={320}
+            margin={{ top: 24, right: 24, bottom: 24, left: 50 }}
+            grid={{ horizontal: true }}
+            slotProps={{
+              tooltip: {
+                sx: {
+                  '& .MuiChartsTooltip-table caption': {
+                    textAlign: 'right',
+                  },
+                },
+              },
+            }}
+            xAxis={[
+              {
+                id: 'months',
+                scaleType: 'point',
+                data: chartData.map((point) => point.monthLabel),
+                valueFormatter: (value, context) =>
+                  context.location === 'tooltip'
+                    ? formatMonthLabel(value)
+                    : value,
+              },
+            ]}
+            yAxis={[
+              {
+                min: yBounds.min,
+                max: yBounds.max,
+                valueFormatter: (value: number) => `${value} min`,
+              },
+            ]}
+            series={[
+              {
+                id: 'avg-duration',
+                data: chartData.map((point) => point.avgMinutes),
+                color: palette.meetings[500],
+                curve: 'linear',
+                showMark: true,
+                valueFormatter: (value: number | null) =>
+                  value == null ? '' : formatDuration(value),
+              },
+            ]}
+            sx={{
+              '.MuiMarkElement-root': {
+                stroke: palette.meetings[500],
+                strokeWidth: 2,
+                fill: palette.meetings[500],
+              },
+              '.MuiMarkElement-root[data-highlighted="true"]': {
+                stroke: palette.meetings[500],
+                fill: palette.meetings[500],
+                strokeWidth: 3,
+              },
+            }}
+          />
+        )}
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
@@ -1,3 +1,5 @@
+import { EAvgDurationLineChart } from '@data/enums/EAvgDurationLineChart';
+import { ECardLabel } from '@data/enums/ECardLabel';
 import ShowChartOutlinedIcon from '@mui/icons-material/ShowChartOutlined';
 import {
   Box,
@@ -7,38 +9,16 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import { LineChart } from '@mui/x-charts/LineChart';
 import { useDashboardAvgDuration } from '@store/hooks/useDashboardAvgDuration';
 import type { JSX } from 'react';
 import { useMemo } from 'react';
 
+import { StyledLineChart } from './AvgDurationLineChart.style';
 import { formatDuration, formatMonthLabel } from './AvgDurationLineChart.utils';
-
-type TChartYBounds = {
-  min: number;
-  max: number;
-};
-
-const resolveYBounds = (values: number[]): TChartYBounds => {
-  const minValue = Math.min(...values);
-  const maxValue = Math.max(...values);
-
-  if (minValue === maxValue) {
-    const padding = Math.max(1, minValue * 0.2);
-    return {
-      min: Math.max(0, Number((minValue - padding).toFixed(1))),
-      max: Number((maxValue + padding).toFixed(1)),
-    };
-  }
-
-  const range = maxValue - minValue;
-  const padding = range * 0.15;
-
-  return {
-    min: Math.max(0, Number((minValue - padding).toFixed(1))),
-    max: Number((maxValue + padding).toFixed(1)),
-  };
-};
+import {
+  resolveYBounds,
+  type TChartYBounds,
+} from './AvgDurationLineChart.yBounds.utils';
 
 export const AvgDurationLineChart = (): JSX.Element => {
   const { palette } = useTheme();
@@ -72,7 +52,9 @@ export const AvgDurationLineChart = (): JSX.Element => {
     >
       <Stack spacing={2}>
         <Stack spacing={0.5}>
-          <Typography variant="h4">Duração média das reuniões</Typography>
+          <Typography variant="h4">
+            {ECardLabel.AVERAGE_MEETINGS_DURATION}
+          </Typography>
         </Stack>
 
         {isLoading ? (
@@ -94,14 +76,14 @@ export const AvgDurationLineChart = (): JSX.Element => {
             sx={{ minHeight: '18rem' }}
           >
             <Typography variant="subtitle1" fontWeight={700}>
-              Não foi possível carregar o gráfico
+              {EAvgDurationLineChart.ERROR_TITLE}
             </Typography>
             <Typography
               variant="body2"
               color="text.secondary"
               textAlign="center"
             >
-              Tente novamente em instantes.
+              {EAvgDurationLineChart.ERROR_DESCRIPTION}
             </Typography>
           </Stack>
         ) : chartData.length === 0 ? (
@@ -126,19 +108,19 @@ export const AvgDurationLineChart = (): JSX.Element => {
               <ShowChartOutlinedIcon />
             </Box>
             <Typography variant="subtitle1" fontWeight={700}>
-              Sem dados de duração média no momento
+              {EAvgDurationLineChart.EMPTY_TITLE}
             </Typography>
             <Typography
               variant="body2"
               color="text.secondary"
               textAlign="center"
             >
-              Assim que houver reuniões consolidadas, o gráfico será exibido
-              aqui.
+              {EAvgDurationLineChart.EMPTY_DESCRIPTION}
             </Typography>
           </Stack>
         ) : (
-          <LineChart
+          <StyledLineChart
+            lineColor={palette.meetings[500]}
             height={320}
             margin={{ top: 24, right: 24, bottom: 24, left: 50 }}
             grid={{ horizontal: true }}
@@ -180,18 +162,6 @@ export const AvgDurationLineChart = (): JSX.Element => {
                   value == null ? '' : formatDuration(value),
               },
             ]}
-            sx={{
-              '.MuiMarkElement-root': {
-                stroke: palette.meetings[500],
-                strokeWidth: 2,
-                fill: palette.meetings[500],
-              },
-              '.MuiMarkElement-root[data-highlighted="true"]': {
-                stroke: palette.meetings[500],
-                fill: palette.meetings[500],
-                strokeWidth: 3,
-              },
-            }}
           />
         )}
       </Stack>

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils.ts
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils.ts
@@ -1,0 +1,44 @@
+const FULL_MONTH_LABELS: Record<string, string> = {
+  Jan: 'Janeiro',
+  Fev: 'Fevereiro',
+  Mar: 'Março',
+  Abr: 'Abril',
+  Mai: 'Maio',
+  Jun: 'Junho',
+  Jul: 'Julho',
+  Ago: 'Agosto',
+  Set: 'Setembro',
+  Out: 'Outubro',
+  Nov: 'Novembro',
+  Dez: 'Dezembro',
+};
+
+export const formatMonthLabel = (monthLabel: string): string => {
+  return FULL_MONTH_LABELS[monthLabel] ?? monthLabel;
+};
+
+const pluralize = (
+  value: number,
+  singularLabel: string,
+  pluralLabel: string
+): string => {
+  return `${value} ${value === 1 ? singularLabel : pluralLabel}`;
+};
+
+export const formatDuration = (value: number): string => {
+  const roundedMinutes = Math.max(0, Math.round(value));
+
+  if (roundedMinutes < 60) {
+    return pluralize(roundedMinutes, 'minuto', 'minutos');
+  }
+
+  const hours = Math.floor(roundedMinutes / 60);
+  const minutes = roundedMinutes % 60;
+  const hourText = pluralize(hours, 'hora', 'horas');
+
+  if (minutes === 0) {
+    return hourText;
+  }
+
+  return `${hourText} e ${pluralize(minutes, 'minuto', 'minutos')}`;
+};

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.yBounds.utils.ts
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.yBounds.utils.ts
@@ -1,0 +1,35 @@
+export type TChartYBounds = {
+  min: number;
+  max: number;
+};
+
+const EQUAL_VALUES_PADDING_RATIO = 0.2;
+const RANGE_PADDING_RATIO = 0.15;
+const MIN_EQUAL_VALUES_PADDING = 1;
+
+const getBoundValue = (value: number): number => Number(value.toFixed(1));
+
+export const resolveYBounds = (values: number[]): TChartYBounds => {
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+
+  if (minValue === maxValue) {
+    const padding = Math.max(
+      MIN_EQUAL_VALUES_PADDING,
+      minValue * EQUAL_VALUES_PADDING_RATIO
+    );
+
+    return {
+      min: Math.max(0, getBoundValue(minValue - padding)),
+      max: getBoundValue(maxValue + padding),
+    };
+  }
+
+  const range = maxValue - minValue;
+  const padding = range * RANGE_PADDING_RATIO;
+
+  return {
+    min: Math.max(0, getBoundValue(minValue - padding)),
+    max: getBoundValue(maxValue + padding),
+  };
+};

--- a/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformation.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformation.tsx
@@ -1,5 +1,6 @@
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { Close, Save } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
 import { Box, Button } from '@mui/material';
 import type { TManager } from '@services/models/ManagerSchema';
 import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
@@ -39,7 +40,7 @@ export const ManagerInformation = ({
           <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <Button
               variant="outlined"
-              startIcon={<Close />}
+              startIcon={<CloseIcon />}
               onClick={handleCancelEdit}
               disabled={updateManagerMutation.isPending}
             >
@@ -47,7 +48,7 @@ export const ManagerInformation = ({
             </Button>
             <Button
               variant="contained"
-              startIcon={<Save />}
+              startIcon={<SaveIcon />}
               onClick={handleSaveEdit}
               disabled={!isEditFormValid || updateManagerMutation.isPending}
             >

--- a/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationView/ManagerInformationView.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationView/ManagerInformationView.tsx
@@ -1,4 +1,5 @@
-import { Business, Email } from '@mui/icons-material';
+import BusinessIcon from '@mui/icons-material/Business';
+import EmailIcon from '@mui/icons-material/Email';
 import { Box } from '@mui/material';
 import type { TManager } from '@services/models/ManagerSchema';
 import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
@@ -24,7 +25,7 @@ export const ManagerInformationView = ({
     <ItemDetail
       label="Empresa"
       value={manager.company.name}
-      icon={<Business fontSize="small" />}
+      icon={<BusinessIcon fontSize="small" />}
     />
 
     <ItemDetail label="Nome do usuário" value={manager.name} />
@@ -38,7 +39,7 @@ export const ManagerInformationView = ({
     <ItemDetail
       label="Email de acesso"
       value={manager.email}
-      icon={<Email fontSize="small" />}
+      icon={<EmailIcon fontSize="small" />}
     />
   </Box>
 );

--- a/src/pages/ManagersPage/ManagersDetails/ManagersDetails.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagersDetails.tsx
@@ -1,5 +1,5 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
-import { ArrowBack } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Link as MuiLink, Typography, useTheme } from '@mui/material';
 import { PageNotFound } from '@pages/PageNotFound/PageNotFound';
 import { useGetManagerById } from '@services/queries/useManagers';
@@ -52,7 +52,7 @@ export const ManagersDetails = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para gestores
         </MuiLink>
 

--- a/src/pages/PageNotFound/PageNotFound.tsx
+++ b/src/pages/PageNotFound/PageNotFound.tsx
@@ -1,4 +1,4 @@
-import { Home as HomeIcon } from '@mui/icons-material';
+import HomeIcon from '@mui/icons-material/Home';
 import { Box, Button, Container, Typography } from '@mui/material';
 import { useNavigate } from '@tanstack/react-router';
 import type { JSX } from 'react';

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -1,6 +1,8 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { ArrowBack, Close, Save } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
 import {
   Box,
   Button,
@@ -84,7 +86,7 @@ export const SalesmanDetail = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para vendedores
         </MuiLink>
 
@@ -103,14 +105,14 @@ export const SalesmanDetail = (): JSX.Element => {
               >
                 <Button
                   variant="outlined"
-                  startIcon={<Close />}
+                  startIcon={<CloseIcon />}
                   onClick={handleCancelEdit}
                 >
                   Cancelar
                 </Button>
                 <Button
                   variant="contained"
-                  startIcon={<Save />}
+                  startIcon={<SaveIcon />}
                   onClick={handleSaveEdit}
                   disabled={!isEditFormValid}
                 >

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
@@ -1,4 +1,5 @@
-import { Business, Email } from '@mui/icons-material';
+import BusinessIcon from '@mui/icons-material/Business';
+import EmailIcon from '@mui/icons-material/Email';
 import { Box } from '@mui/material';
 import type { TSalesman } from '@services/models/SalesmanSchema';
 import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
@@ -24,7 +25,7 @@ export const SalesmanInformationView = ({
     <ItemDetail
       label="Empresa"
       value={salesman.company.name}
-      icon={<Business fontSize="small" />}
+      icon={<BusinessIcon fontSize="small" />}
     />
 
     <ItemDetail label="Nome do usuário" value={salesman.name} />
@@ -38,7 +39,7 @@ export const SalesmanInformationView = ({
     <ItemDetail
       label="Email de acesso"
       value={salesman.email}
-      icon={<Email fontSize="small" />}
+      icon={<EmailIcon fontSize="small" />}
     />
   </Box>
 );

--- a/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailHeaderStats/MeetingDetailHeaderStats.tsx
+++ b/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailHeaderStats/MeetingDetailHeaderStats.tsx
@@ -1,6 +1,6 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { getSentimentConfig } from '@hooks/useSentiment';
-import { ArrowBack } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
 import { IconButton, Link as MuiLink, Stack, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
@@ -55,7 +55,7 @@ export const MeetingDetailHeaderStats = ({
           fontSize: '0.875rem',
         }}
       >
-        <ArrowBack sx={{ fontSize: '0.875rem' }} />
+        <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
         Voltar para reuniões
       </MuiLink>
 

--- a/src/store/hooks/useDashboardAvgDuration.ts
+++ b/src/store/hooks/useDashboardAvgDuration.ts
@@ -1,0 +1,22 @@
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  dashboardApi,
+  type TDashboardAvgDurationPoint,
+} from '../../apis/dashboardApi';
+
+export const dashboardAvgDurationQueryKeys = {
+  all: ['dashboard-avg-duration'] as const,
+};
+
+export const useDashboardAvgDuration = (
+  options?: UseQueryOptions<TDashboardAvgDurationPoint[]>
+): ReturnType<typeof useQuery<TDashboardAvgDurationPoint[], Error>> => {
+  return useQuery<TDashboardAvgDurationPoint[], Error>({
+    queryKey: dashboardAvgDurationQueryKeys.all,
+    queryFn: () => dashboardApi.getAvgDuration(),
+    staleTime: 0,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Issue relacionada

N/A.

## O que foi implementado?

Este PR ajusta imports de ícones do MUI que utilizavam o barrel:
`import { Edit } from '@mui/icons-material'`

para imports diretos por ícone:
`import EditIcon from '@mui/icons-material/Edit'`

A alteração foi aplicada em diferentes arquivos da aplicação onde ainda existia o padrão anterior.

## Por que essa mudança é necessária?

Essa mudança surgiu após problemas locais de infraestrutura durante execução dos testes com Vitest, especificamente erros:

* EMFILE
* ENFILE
* too many open files

Durante investigação, a causa identificada foi o uso de imports via barrel do pacote **@mui/icons-material**, que força a resolução de muitos módulos simultaneamente.

Os imports diretos reduzem a quantidade de arquivos resolvidos pelo bundler/test runner e seguem uma prática recomendada pelo próprio ecossistema MUI.

Importante:

* esta alteração não modifica regra de negócio;
* não altera comportamento visual da aplicação;
* não era uma demanda obrigatória da sprint;
* foi realizada principalmente para resolver o problema local que eu estava enfrentando durante execução dos testes.

Caso consigam validar localmente e considerem a melhoria válida para o projeto, agradeço muito a revisão/aprovação!

## Como testar?

1. Executar os testes normalmente: `pnpm -s test:run`
2. Validar que os testes executam sem erros relacionados a:
    * EMFILE
    * ENFILE
    * too many open files

3. Validar que a aplicação continua funcionando visualmente como antes.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças
