### PR TITLE
refactor: replace MUI barrel imports with direct icon imports

### DIFF
--- a/src/UI/EntityDetailsCard/EntityDetailsCard.tsx
+++ b/src/UI/EntityDetailsCard/EntityDetailsCard.tsx
@@ -1,4 +1,4 @@
-import { Edit } from '@mui/icons-material';
+import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import type { JSX, ReactNode } from 'react';
 
@@ -45,7 +45,11 @@ export const EntityDetailsCard = ({
 
         {headerRight ??
           (onEdit && (
-            <Button variant="contained" startIcon={<Edit />} onClick={onEdit}>
+            <Button
+              variant="contained"
+              startIcon={<EditIcon />}
+              onClick={onEdit}
+            >
               Editar
             </Button>
           ))}

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
@@ -1,7 +1,7 @@
 import { ECardLabel } from '@data/enums/ECardLabel';
 import { EPageRoutes } from '@data/enums/EPageRoutes';
-import { ArrowBack } from '@mui/icons-material';
 import ApartmentOutlinedIcon from '@mui/icons-material/ApartmentOutlined';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import {
   IconButton,
   Link as MuiLink,
@@ -68,7 +68,7 @@ export const CompanyDetail = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para empresas
         </MuiLink>
 

--- a/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformation.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformation.tsx
@@ -1,5 +1,6 @@
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { Close, Save } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
 import { Box, Button } from '@mui/material';
 import type { TManager } from '@services/models/ManagerSchema';
 import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
@@ -39,7 +40,7 @@ export const ManagerInformation = ({
           <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
             <Button
               variant="outlined"
-              startIcon={<Close />}
+              startIcon={<CloseIcon />}
               onClick={handleCancelEdit}
               disabled={updateManagerMutation.isPending}
             >
@@ -47,7 +48,7 @@ export const ManagerInformation = ({
             </Button>
             <Button
               variant="contained"
-              startIcon={<Save />}
+              startIcon={<SaveIcon />}
               onClick={handleSaveEdit}
               disabled={!isEditFormValid || updateManagerMutation.isPending}
             >

--- a/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationView/ManagerInformationView.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagerInformation/ManagerInformationView/ManagerInformationView.tsx
@@ -1,4 +1,5 @@
-import { Business, Email } from '@mui/icons-material';
+import BusinessIcon from '@mui/icons-material/Business';
+import EmailIcon from '@mui/icons-material/Email';
 import { Box } from '@mui/material';
 import type { TManager } from '@services/models/ManagerSchema';
 import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
@@ -24,7 +25,7 @@ export const ManagerInformationView = ({
     <ItemDetail
       label="Empresa"
       value={manager.company.name}
-      icon={<Business fontSize="small" />}
+      icon={<BusinessIcon fontSize="small" />}
     />
 
     <ItemDetail label="Nome do usuário" value={manager.name} />
@@ -38,7 +39,7 @@ export const ManagerInformationView = ({
     <ItemDetail
       label="Email de acesso"
       value={manager.email}
-      icon={<Email fontSize="small" />}
+      icon={<EmailIcon fontSize="small" />}
     />
   </Box>
 );

--- a/src/pages/ManagersPage/ManagersDetails/ManagersDetails.tsx
+++ b/src/pages/ManagersPage/ManagersDetails/ManagersDetails.tsx
@@ -1,5 +1,5 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
-import { ArrowBack } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Link as MuiLink, Typography, useTheme } from '@mui/material';
 import { PageNotFound } from '@pages/PageNotFound/PageNotFound';
 import { useGetManagerById } from '@services/queries/useManagers';
@@ -52,7 +52,7 @@ export const ManagersDetails = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para gestores
         </MuiLink>
 

--- a/src/pages/PageNotFound/PageNotFound.tsx
+++ b/src/pages/PageNotFound/PageNotFound.tsx
@@ -1,4 +1,4 @@
-import { Home as HomeIcon } from '@mui/icons-material';
+import HomeIcon from '@mui/icons-material/Home';
 import { Box, Button, Container, Typography } from '@mui/material';
 import { useNavigate } from '@tanstack/react-router';
 import type { JSX } from 'react';

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -1,6 +1,8 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { ArrowBack, Close, Save } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
 import {
   Box,
   Button,
@@ -84,7 +86,7 @@ export const SalesmanDetail = (): JSX.Element => {
             fontSize: '0.875rem',
           }}
         >
-          <ArrowBack sx={{ fontSize: '0.875rem' }} />
+          <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
           Voltar para vendedores
         </MuiLink>
 
@@ -103,14 +105,14 @@ export const SalesmanDetail = (): JSX.Element => {
               >
                 <Button
                   variant="outlined"
-                  startIcon={<Close />}
+                  startIcon={<CloseIcon />}
                   onClick={handleCancelEdit}
                 >
                   Cancelar
                 </Button>
                 <Button
                   variant="contained"
-                  startIcon={<Save />}
+                  startIcon={<SaveIcon />}
                   onClick={handleSaveEdit}
                   disabled={!isEditFormValid}
                 >

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
@@ -1,4 +1,5 @@
-import { Business, Email } from '@mui/icons-material';
+import BusinessIcon from '@mui/icons-material/Business';
+import EmailIcon from '@mui/icons-material/Email';
 import { Box } from '@mui/material';
 import type { TSalesman } from '@services/models/SalesmanSchema';
 import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
@@ -24,7 +25,7 @@ export const SalesmanInformationView = ({
     <ItemDetail
       label="Empresa"
       value={salesman.company.name}
-      icon={<Business fontSize="small" />}
+      icon={<BusinessIcon fontSize="small" />}
     />
 
     <ItemDetail label="Nome do usuário" value={salesman.name} />
@@ -38,7 +39,7 @@ export const SalesmanInformationView = ({
     <ItemDetail
       label="Email de acesso"
       value={salesman.email}
-      icon={<Email fontSize="small" />}
+      icon={<EmailIcon fontSize="small" />}
     />
   </Box>
 );

--- a/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailHeaderStats/MeetingDetailHeaderStats.tsx
+++ b/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingDetailHeaderStats/MeetingDetailHeaderStats.tsx
@@ -1,6 +1,6 @@
 import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { getSentimentConfig } from '@hooks/useSentiment';
-import { ArrowBack } from '@mui/icons-material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
 import { IconButton, Link as MuiLink, Stack, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
@@ -55,7 +55,7 @@ export const MeetingDetailHeaderStats = ({
           fontSize: '0.875rem',
         }}
       >
-        <ArrowBack sx={{ fontSize: '0.875rem' }} />
+        <ArrowBackIcon sx={{ fontSize: '0.875rem' }} />
         Voltar para reuniões
       </MuiLink>
 


### PR DESCRIPTION
## Issue relacionada

N/A.

## O que foi implementado?

Este PR ajusta imports de ícones do MUI que utilizavam o barrel:
`import { Edit } from '@mui/icons-material'`

para imports diretos por ícone:
`import EditIcon from '@mui/icons-material/Edit'`

A alteração foi aplicada em diferentes arquivos da aplicação onde ainda existia o padrão anterior.

## Por que essa mudança é necessária?

Essa mudança surgiu após problemas locais de infraestrutura durante execução dos testes com Vitest, especificamente erros:

* EMFILE
* ENFILE
* too many open files

Durante investigação, a causa identificada foi o uso de imports via barrel do pacote **@mui/icons-material**, que força a resolução de muitos módulos simultaneamente.

Os imports diretos reduzem a quantidade de arquivos resolvidos pelo bundler/test runner e seguem uma prática recomendada pelo próprio ecossistema MUI.

Importante:

* esta alteração não modifica regra de negócio;
* não altera comportamento visual da aplicação;
* não era uma demanda obrigatória da sprint;
* foi realizada principalmente para resolver o problema local que eu estava enfrentando durante execução dos testes.

Caso consigam validar localmente e considerem a melhoria válida para o projeto, agradeço muito a revisão/aprovação!

## Como testar?

1. Executar os testes normalmente: `pnpm -s test:run`
2. Validar que os testes executam sem erros relacionados a:
    * EMFILE
    * ENFILE
    * too many open files

3. Validar que a aplicação continua funcionando visualmente como antes.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças