### PR TITLE
fix: use duration icon for average meetings duration stat

### DIFF
--- a/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyDetail.tsx
@@ -131,8 +131,8 @@ export const CompanyDetail = (): JSX.Element => {
             sx={{ flex: '1 1 0', minWidth: { xs: '100%', sm: 160 } }}
           />
           <StatCard
-            iconName="meeting"
-            theme="meetings"
+            iconName="duration"
+            theme="neutrals"
             value={'30 min'}
             label={ECardLabel.AVERAGE_MEETINGS_DURATION}
             sx={{ flex: '1 1 0', minWidth: { xs: '100%', sm: 160 } }}


### PR DESCRIPTION
## Issue relacionada

#48 

## O que foi implementado?

* Alteração do ícone utilizado no StatCard de duração média das reuniões na tela de detalhes da empresa.
* Substituição de iconName="meeting" por iconName="duration".
* Ajuste do tema visual de meetings para neutrals.

## Por que essa mudança é necessária?

O card de duração média estava utilizando um ícone semântico incorreto relacionado a reuniões/eventos `(EventNoteIcon)`.

A alteração aplica o ícone de duração/tempo `(AccessTimeIcon)`, deixando a interface mais consistente semanticamente.

## Como testar?

1. Acessar a tela de detalhes de empresa.
2. Verificar o card de duração média das reuniões.
3. Confirmar que o ícone exibido é o de relógio/duração.
4. Confirmar que os demais StatCards permanecem inalterados.

Observação: atualmente existem inconsistências no formato de alguns dados retornados pela API e consumidos pelo frontend, o que pode dificultar a validação visual. Este PR não altera nenhuma dessas integrações ou contratos, contemplando apenas a correção solicitada nesta task. 

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças