### PR TITLE
refactor: login inputs behavior

### DIFF
--- a/src/pages/Login/LoginForm/LoginForm.test.tsx
+++ b/src/pages/Login/LoginForm/LoginForm.test.tsx
@@ -8,6 +8,7 @@ vi.mock('./useLoginForm', () => ({
     errors: {},
     onSubmit: vi.fn(),
     setValue: vi.fn(),
+    watch: vi.fn(() => ''),
   }),
 }));
 

--- a/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/src/pages/Login/LoginForm/LoginForm.tsx
@@ -12,7 +12,11 @@ import { DemoAccountsInfo } from './DemoAccountsInfo/DemoAccountsInfo';
 import { useLoginForm } from './useLoginForm';
 
 export const LoginForm = (): JSX.Element => {
-  const { register, handleSubmit, errors, onSubmit, setValue } = useLoginForm();
+  const { register, handleSubmit, errors, onSubmit, setValue, watch } =
+    useLoginForm();
+
+  const emailValue = watch('email');
+  const passwordValue = watch('password');
 
   const handleFormSubmit = handleSubmit(onSubmit);
 
@@ -38,6 +42,7 @@ export const LoginForm = (): JSX.Element => {
             sx={{ mb: 2 }}
             error={!!errors.email}
             helperText={errors.email?.message}
+            InputLabelProps={{ shrink: Boolean(emailValue) }}
             {...register('email')}
           />
 
@@ -51,6 +56,7 @@ export const LoginForm = (): JSX.Element => {
             sx={{ mb: 3 }}
             error={!!errors.password || !!errors.root}
             helperText={errors.password?.message || errors.root?.message}
+            InputLabelProps={{ shrink: Boolean(passwordValue) }}
             {...register('password')}
           />
 

--- a/src/pages/Login/LoginForm/useLoginForm.ts
+++ b/src/pages/Login/LoginForm/useLoginForm.ts
@@ -22,8 +22,13 @@ export const useLoginForm = (): UseLoginFormReturn => {
     setError,
     clearErrors,
     setValue,
+    watch,
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
   });
 
   const onSubmit = async (data: LoginFormData): Promise<void> => {
@@ -45,5 +50,6 @@ export const useLoginForm = (): UseLoginFormReturn => {
     errors,
     onSubmit,
     setValue,
+    watch,
   };
 };

--- a/src/types/hooks.d.ts
+++ b/src/types/hooks.d.ts
@@ -3,6 +3,7 @@ import type {
   UseFormHandleSubmit,
   UseFormRegister,
   UseFormSetValue,
+  UseFormWatch,
 } from 'react-hook-form';
 
 export type TColorThemeOptions =
@@ -33,4 +34,5 @@ export type UseLoginFormReturn = {
   errors: FieldErrors<LoginFormData>;
   onSubmit: (data: LoginFormData) => Promise<void>;
   setValue: UseFormSetValue<LoginFormData>;
+  watch: UseFormWatch<LoginFormData>;
 };


### PR DESCRIPTION
## Issue relacionada

nenhuma

## O que foi implementado?

ao adicionar email e senha no login ou selecionar um login, o label estava ficando em cima, botei um escutador para quando tem dado ficar o label em cima do input e nãoa no centro 

## Por que essa mudança é necessária?

estética


## Como testar?

preencheer os inputs de login

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
