### PR TITLE
fix: pushar tag latest da imagem junto com o SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,7 @@ jobs:
       - name: Build and push
         run: |
           IMAGE_TAG=${{ secrets.ECR_REGISTRY }}/salespilot/web:${{ github.sha }}
-          docker build -t $IMAGE_TAG .
+          IMAGE_LATEST=${{ secrets.ECR_REGISTRY }}/salespilot/web:latest
+          docker build -t $IMAGE_TAG -t $IMAGE_LATEST .
           docker push $IMAGE_TAG
+          docker push $IMAGE_LATEST


### PR DESCRIPTION
## What

Adiciona a tag `latest` no build da imagem `salespilot/web`, pushando ela junto com a tag do commit SHA no ECR.

## Why

O `docker-compose.prod.yml` do Backend referencia `salespilot/web:latest`, mas o CI só pushava a tag do SHA — a tag `latest` nunca existiu no ECR. Sem esse fix, o `docker compose pull` do deploy do Backend falha e derruba o deploy inteiro.

Mesma correção já aplicada no pipeline do Backend.

## How to review

- Único arquivo alterado: `.github/workflows/ci.yml`, job `docker-build-push`
- O build agora gera as duas tags (`-t sha -t latest`) e pusha ambas
- Rollback continua possível pela tag do SHA

## Checklist

- [x] Self-review performed
- [ ] Tests cover the changes
- [x] No breaking changes (or explained above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)