### PR TITLE
fix: skip lifecycle scripts in Docker build (lefthook broke the image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
 RUN pnpm build


### PR DESCRIPTION
## What

Adiciona `--ignore-scripts` ao `pnpm install` do Dockerfile.

## Why

O build da imagem na main falhou: o `pnpm install` dispara o script `prepare` (`lefthook install`), que precisa de git e de um repositório `.git` — nenhum dos dois existe (nem deve existir) dentro do build Docker.

Lefthook é git hook de ambiente de desenvolvimento; não tem função na imagem. O `pnpm build` roda separado no passo seguinte e não é afetado. O pnpm 10 já não executa postinstall de dependências por padrão, então o `--ignore-scripts` só elimina o `prepare`.

Esse fix desbloqueia o push da imagem `web:latest` pro ECR, que por sua vez desbloqueia o deploy do Backend (que falhou com `manifest for salespilot/web:latest not found`).

## How to review

- Única linha alterada no `Dockerfile`
- Validado localmente: `docker build` completa e a imagem serve o app via nginx (HTTP 200)

## Checklist

- [x] Self-review performed
- [ ] Tests cover the changes
- [x] No breaking changes (or explained above)
