### PR TITLE
fix: proxy API requests through nginx to avoid CORS and hardcoded host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
+ENV VITE_API_URL=/
 RUN pnpm build
 
 FROM nginx:alpine
 
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://api:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## What

- Adiciona `nginx.conf` com proxy reverso: `location /api/` repassa pro container `api:8080` na rede interna do compose, e `try_files` garante fallback de SPA pra rotas do React Router
- Builda o bundle com `VITE_API_URL=/`, fazendo o axios usar URLs relativas (same-origin)

## Why

Em produção o app quebrava com **CORS blocked** ao chamar `http://localhost:8080/api/auth/login`: o bundle era buildado sem `VITE_API_URL`, caindo no fallback `localhost:8080` do `apiClient.ts` — e mesmo com a URL certa, o CORS do backend só permite `localhost:5173/5174`.

Com o proxy same-origin:
- Nenhum IP/host fica hardcoded no bundle (sobrevive a troca de IP da instância)
- CORS deixa de existir em produção (browser → nginx → api, mesma origem)
- O CORS do backend permanece intacto pro fluxo de dev local (vite na 5173)

## How to review

- `nginx.conf`: proxy em `/api/` + SPA fallback
- `Dockerfile`: `ENV VITE_API_URL=/` antes do build + COPY do nginx.conf
- Validado localmente com rede docker simulando o compose: SPA 200, deep link 200, `/api/` proxiado pro container `api`, e `grep localhost:8080` no bundle retorna 0 ocorrências

## Checklist

- [x] Self-review performed
- [ ] Tests cover the changes
- [x] No breaking changes (or explained above)