### PR TITLE
Refactor/49/company detail info

### DIFF
--- a/src/data/enums/EPageTitles.ts
+++ b/src/data/enums/EPageTitles.ts
@@ -6,6 +6,7 @@ export const EPageTitles = {
   COMPANIES: 'Empresas',
   MANAGERS: 'Gestores',
   MANAGER_INFORMATION: 'Informações do gestor',
+  COMPANY_INFORMATION: 'Informações da empresa',
   SALESMEN: 'Vendedores',
   SALESMAN_INFORMATION: 'Informações do vendedor',
   MEETINGS: 'Reuniões',

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformation.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformation.tsx
@@ -1,5 +1,7 @@
+import { EPageTitles } from '@data/enums/EPageTitles';
 import EditIcon from '@mui/icons-material/Edit';
-import { Button, Paper, Stack, Typography, useTheme } from '@mui/material';
+import { Button } from '@mui/material';
+import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
 import type { JSX } from 'react';
 
 import { CompanyInformationView } from './CompanyInformationView/CompanyInformationView';
@@ -13,37 +15,17 @@ export interface ICompanyInformationProps {
 export const CompanyInformation = ({
   viewValues,
   onEdit,
-}: ICompanyInformationProps): JSX.Element => {
-  const { palette } = useTheme();
-
-  return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: { xs: 2, sm: 3 },
-        width: '100%',
-        border: `1px solid ${palette.neutrals[200]}`,
-      }}
-    >
-      <Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        flexWrap="wrap"
-        gap={1.5}
-        sx={{ mb: 3 }}
-      >
-        <Typography variant="h2">Informações da empresa</Typography>
-        <Button
-          variant="contained"
-          startIcon={<EditIcon />}
-          onClick={onEdit}
-          aria-label="Editar informações da empresa"
-        >
+}: ICompanyInformationProps): JSX.Element => (
+  <EntityDetailsCard
+    title={EPageTitles.COMPANY_INFORMATION}
+    headerRight={
+      onEdit ? (
+        <Button variant="contained" startIcon={<EditIcon />} onClick={onEdit}>
           Editar
         </Button>
-      </Stack>
-      <CompanyInformationView {...viewValues} />
-    </Paper>
-  );
-};
+      ) : undefined
+    }
+  >
+    <CompanyInformationView {...viewValues} />
+  </EntityDetailsCard>
+);

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEdit.test.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEdit.test.tsx
@@ -32,9 +32,7 @@ const draft = {
 describe('CompanyInformationEdit', () => {
   it('renders edit heading', () => {
     render(<CompanyInformationEdit draft={draft} setDraft={vi.fn()} />);
-    expect(
-      screen.getByText('Editar informações da empresa')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Informações da empresa')).toBeInTheDocument();
   });
 
   it('renders Cancelar and Salvar buttons', () => {

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEdit.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEdit.tsx
@@ -1,4 +1,8 @@
-import { Button, Paper, Stack, Typography } from '@mui/material';
+import { EPageTitles } from '@data/enums/EPageTitles';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
+import { Box, Button } from '@mui/material';
+import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
 import type { Dispatch, JSX, SetStateAction } from 'react';
 
 import type { CompanyInformationValues } from '../CompanyInformationView/types';
@@ -34,37 +38,29 @@ export const CompanyInformationEdit = ({
   });
 
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: { xs: 2, sm: 3 },
-        width: '100%',
-        border: `1px solid ${palette.neutrals[200]}`,
-      }}
-    >
-      <Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        flexWrap="wrap"
-        gap={1.5}
-        sx={{ mb: 3 }}
-      >
-        <Typography variant="h2">Editar informações da empresa</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button variant="text" onClick={onCancel}>
+    <EntityDetailsCard
+      title={EPageTitles.COMPANY_INFORMATION}
+      headerRight={
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <Button
+            variant="outlined"
+            startIcon={<CloseIcon />}
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
             Cancelar
           </Button>
           <Button
             variant="contained"
+            startIcon={<SaveIcon />}
             onClick={handleSubmit(onSubmit)}
             disabled={!isValid || isSubmitting}
           >
             Salvar
           </Button>
-        </Stack>
-      </Stack>
-
+        </Box>
+      }
+    >
       <CompanyInformationEditFields
         draft={draft}
         setDraft={setDraft}
@@ -73,6 +69,6 @@ export const CompanyInformationEdit = ({
         valueColor={valueColor}
         palette={palette}
       />
-    </Paper>
+    </EntityDetailsCard>
   );
 };

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
@@ -62,54 +62,7 @@ export const CompanyInformationEditFields = ({
           'ID da empresa',
           <Typography fontWeight={600}>{draft.id}</Typography>
         )}
-        <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
-            Nome da empresa
-          </Typography>
-          <Controller
-            name="name"
-            control={control}
-            render={({ field, fieldState }) => (
-              <TextField
-                {...field}
-                fullWidth
-                size="small"
-                error={!!fieldState.error}
-                helperText={fieldState.error?.message}
-                onChange={(e) => {
-                  field.onChange(e);
-                  setDraft((d) => ({ ...d, name: e.target.value }));
-                }}
-              />
-            )}
-          />
-        </Stack>
         {row('CNPJ', <Typography fontWeight={600}>{draft.tax_id}</Typography>)}
-        <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
-            Telefone
-          </Typography>
-          <TextField
-            fullWidth
-            value={'99999-9999'}
-            onChange={(e) => setDraft((d) => ({ ...d, phone: e.target.value }))}
-            size="small"
-            slotProps={{
-              input: {
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <PhoneOutlinedIcon
-                      sx={{
-                        fontSize: '1.125rem',
-                        color: palette.neutrals[500],
-                      }}
-                    />
-                  </InputAdornment>
-                ),
-              },
-            }}
-          />
-        </Stack>
         <Stack spacing={0.75}>
           <Typography variant="body2" color={labelColor} fontWeight={500}>
             Endereço
@@ -140,11 +93,58 @@ export const CompanyInformationEditFields = ({
             }}
           />
         </Stack>
+        <Stack spacing={0.75}>
+          <Typography variant="body2" color={labelColor} fontWeight={500}>
+            Telefone
+          </Typography>
+          <TextField
+            fullWidth
+            value={'99999-9999'}
+            onChange={(e) => setDraft((d) => ({ ...d, phone: e.target.value }))}
+            size="small"
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <PhoneOutlinedIcon
+                      sx={{
+                        fontSize: '1.125rem',
+                        color: palette.neutrals[500],
+                      }}
+                    />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </Stack>
       </Stack>
       <Stack
         spacing={2.5}
         sx={{ flex: { md: '1 1 42%' }, minWidth: { md: 200 } }}
       >
+        <Stack spacing={0.75}>
+          <Typography variant="body2" color={labelColor} fontWeight={500}>
+            Nome da empresa
+          </Typography>
+          <Controller
+            name="name"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                fullWidth
+                size="small"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                onChange={(e) => {
+                  field.onChange(e);
+                  setDraft((d) => ({ ...d, name: e.target.value }));
+                }}
+              />
+            )}
+          />
+        </Stack>
         <Stack spacing={0.75}>
           <Typography variant="body2" color={labelColor} fontWeight={500}>
             Plano
@@ -198,8 +198,13 @@ export const CompanyInformationEditFields = ({
             name="active"
             control={control}
             render={({ field }) => (
-              <Stack direction="row" alignItems="center" gap={1.5}>
-                <Typography variant="body2" color={valueColor} fontWeight={500}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                gap={1.5}
+                sx={{ minHeight: '3rem' }}
+              >
+                <Typography variant="h6" fontWeight={500}>
                   {field.value ? EStatus.ACTIVE : EStatus.INACTIVE}
                 </Typography>
                 <Switch
@@ -211,10 +216,11 @@ export const CompanyInformationEditFields = ({
                   }}
                   sx={{
                     '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#2E7D32',
+                      color: palette.success[400],
                     },
                     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                      backgroundColor: '#2E7D32',
+                      backgroundColor: palette.success[200],
+                      opacity: 1,
                     },
                   }}
                   slotProps={{

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
@@ -44,7 +44,7 @@ export const CompanyInformationEditFields = ({
 }: CompanyInformationEditFieldsProps): JSX.Element => {
   const row = (fieldLabel: string, value: ReactNode): JSX.Element => (
     <Stack spacing={0.75}>
-      <Typography variant="body2" color={labelColor} fontWeight={500}>
+      <Typography variant="body2" color={labelColor}>
         {fieldLabel}
       </Typography>
       <Box sx={{ color: valueColor }}>{value}</Box>
@@ -58,13 +58,10 @@ export const CompanyInformationEditFields = ({
       alignItems={{ xs: 'stretch', md: 'flex-start' }}
     >
       <Stack spacing={2.5} sx={{ flex: { md: '1 1 58%' } }}>
-        {row(
-          'ID da empresa',
-          <Typography fontWeight={600}>{draft.id}</Typography>
-        )}
-        {row('CNPJ', <Typography fontWeight={600}>{draft.tax_id}</Typography>)}
+        {row('ID da empresa', <Typography variant="h6">{draft.id}</Typography>)}
+        {row('CNPJ', <Typography variant="h6">{draft.tax_id}</Typography>)}
         <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
+          <Typography variant="body2" color={labelColor}>
             Endereço
           </Typography>
           <TextField
@@ -73,7 +70,6 @@ export const CompanyInformationEditFields = ({
             onChange={(e) =>
               setDraft((d) => ({ ...d, address: e.target.value }))
             }
-            size="small"
             slotProps={{
               input: {
                 startAdornment: (
@@ -94,14 +90,13 @@ export const CompanyInformationEditFields = ({
           />
         </Stack>
         <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
+          <Typography variant="body2" color={labelColor}>
             Telefone
           </Typography>
           <TextField
             fullWidth
             value={'99999-9999'}
             onChange={(e) => setDraft((d) => ({ ...d, phone: e.target.value }))}
-            size="small"
             slotProps={{
               input: {
                 startAdornment: (
@@ -124,7 +119,7 @@ export const CompanyInformationEditFields = ({
         sx={{ flex: { md: '1 1 42%' }, minWidth: { md: 200 } }}
       >
         <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
+          <Typography variant="body2" color={labelColor}>
             Nome da empresa
           </Typography>
           <Controller
@@ -134,7 +129,6 @@ export const CompanyInformationEditFields = ({
               <TextField
                 {...field}
                 fullWidth
-                size="small"
                 error={!!fieldState.error}
                 helperText={fieldState.error?.message}
                 onChange={(e) => {
@@ -146,7 +140,7 @@ export const CompanyInformationEditFields = ({
           />
         </Stack>
         <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
+          <Typography variant="body2" color={labelColor}>
             Plano
           </Typography>
           <Controller
@@ -191,7 +185,7 @@ export const CompanyInformationEditFields = ({
           />
         </Stack>
         <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
+          <Typography variant="body2" color={labelColor}>
             Status
           </Typography>
           <Controller

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
@@ -1,9 +1,10 @@
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 import PhoneOutlinedIcon from '@mui/icons-material/PhoneOutlined';
-import { Box, Stack, Typography, useTheme } from '@mui/material';
+import { Box } from '@mui/material';
+import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
 import { PlanBadge } from '@UI/PlanBadge/PlanBadge';
 import { StatusBadge } from '@UI/StatusBadge/StatusBadge';
-import type { JSX, ReactNode } from 'react';
+import type { JSX } from 'react';
 
 import type { CompanyInformationValues } from './types';
 
@@ -13,73 +14,36 @@ export const CompanyInformationView = ({
   tax_id,
   plan,
   active,
-}: CompanyInformationValues): JSX.Element => {
-  const { palette } = useTheme();
-  const labelColor = palette.neutrals[600];
-  const valueColor = palette.neutrals[800];
-
-  const row = (fieldLabel: string, value: ReactNode): JSX.Element => (
-    <Stack spacing={0.75}>
-      <Typography variant="body2" color={labelColor} fontWeight={500}>
-        {fieldLabel}
-      </Typography>
-      <Box sx={{ color: valueColor }}>{value}</Box>
-    </Stack>
-  );
-
-  return (
-    <Stack
-      direction={{ xs: 'column', md: 'row' }}
-      spacing={4}
-      alignItems={{ xs: 'stretch', md: 'flex-start' }}
-    >
-      <Stack spacing={2.5} sx={{ flex: { md: '1 1 58%' } }}>
-        {row('ID da empresa', <Typography fontWeight={600}>{id}</Typography>)}
-        {row(
-          'Nome da empresa',
-          <Typography fontWeight={600}>{name}</Typography>
-        )}
-        {row('CNPJ', <Typography fontWeight={600}>{tax_id}</Typography>)}
-        {row(
-          'Telefone',
-          <Stack direction="row" alignItems="center" gap={1}>
-            <PhoneOutlinedIcon
-              sx={{ fontSize: '1.125rem', color: palette.neutrals[500] }}
-            />
-            <Typography fontWeight={600}>{'99999-9999'}</Typography>
-          </Stack>
-        )}
-        {row(
-          'Endereço',
-          <Stack direction="row" alignItems="flex-start" gap={1}>
-            <LocationOnOutlinedIcon
-              sx={{
-                fontSize: '1.125rem',
-                color: palette.neutrals[500],
-                mt: 0.125,
-              }}
-            />
-            <Typography fontWeight={600}>{'Rua Exemplo, 123'}</Typography>
-          </Stack>
-        )}
-      </Stack>
-      <Stack
-        spacing={2.5}
-        sx={{ flex: { md: '1 1 42%' }, minWidth: { md: 200 } }}
-      >
-        <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
-            Plano
-          </Typography>
-          <PlanBadge plan={plan} sx={{ fontSize: 'small' }} />
-        </Stack>
-        <Stack spacing={0.75}>
-          <Typography variant="body2" color={labelColor} fontWeight={500}>
-            Status
-          </Typography>
-          <StatusBadge active={active} />
-        </Stack>
-      </Stack>
-    </Stack>
-  );
-};
+}: CompanyInformationValues): JSX.Element => (
+  <Box
+    sx={{
+      display: 'grid',
+      gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+      gap: '2rem 4rem',
+    }}
+  >
+    <ItemDetail label="ID da empresa" value={id} />
+    <ItemDetail label="Nome da empresa" value={name} />
+    <ItemDetail label="CNPJ" value={tax_id} />
+    <ItemDetail
+      label="Telefone"
+      value="99999-9999"
+      icon={<PhoneOutlinedIcon fontSize="small" />}
+    />
+    <ItemDetail
+      label="Endereço"
+      value="Rua Exemplo, 123"
+      icon={<LocationOnOutlinedIcon fontSize="small" />}
+    />
+    <ItemDetail label="Plano">
+      <Box sx={{ display: 'inline-flex', alignSelf: 'flex-start' }}>
+        <PlanBadge plan={plan} />
+      </Box>
+    </ItemDetail>
+    <ItemDetail label="Status">
+      <Box sx={{ display: 'inline-flex', alignSelf: 'flex-start' }}>
+        <StatusBadge active={active} />
+      </Box>
+    </ItemDetail>
+  </Box>
+);

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
@@ -25,25 +25,25 @@ export const CompanyInformationView = ({
     <ItemDetail label="ID da empresa" value={id} />
     <ItemDetail label="Nome da empresa" value={name} />
     <ItemDetail label="CNPJ" value={tax_id} />
-    <ItemDetail
-      label="Telefone"
-      value="99999-9999"
-      icon={<PhoneOutlinedIcon fontSize="small" />}
-    />
+    <ItemDetail label="Plano">
+      <Box sx={{ alignSelf: 'flex-start' }}>
+        <PlanBadge plan={plan} />
+      </Box>
+    </ItemDetail>
     <ItemDetail
       label="Endereço"
       value="Rua Exemplo, 123"
       icon={<LocationOnOutlinedIcon fontSize="small" />}
     />
-    <ItemDetail label="Plano">
-      <Box sx={{ display: 'inline-flex', alignSelf: 'flex-start' }}>
-        <PlanBadge plan={plan} />
-      </Box>
-    </ItemDetail>
     <ItemDetail label="Status">
       <Box sx={{ display: 'inline-flex', alignSelf: 'flex-start' }}>
         <StatusBadge active={active} />
       </Box>
     </ItemDetail>
+    <ItemDetail
+      label="Telefone"
+      value="99999-9999"
+      icon={<PhoneOutlinedIcon fontSize="small" />}
+    />
   </Box>
 );

--- a/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingContext/MeetingContext.tsx
+++ b/src/pages/salesman/MeetingsManagement/MeetingDetail/MeetingContext/MeetingContext.tsx
@@ -47,9 +47,9 @@ export const MeetingContext = ({
 
   return (
     <Stack
-      spacing={3}
+      spacing={2}
       sx={{
-        p: 2,
+        p: 2.5,
       }}
     >
       <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## Issue relacionada

#49 

## O que foi implementado?

* Adicionado COMPANY_INFORMATION em EPageTitles.
* Refatorado o card “Informações da empresa” para utilizar EntityDetailsCard como container.
* Movido o botão “Editar” para a prop headerRight, seguindo o padrão utilizado nas telas de gestor e vendedor.
* Refatorado os campos do card para utilizar o componente ItemDetail.
* Substituído o layout baseado em Stack por CSS Grid com duas colunas no breakpoint md.
* Mantida a renderização de PlanBadge e StatusBadge nos respectivos campos.
* Preservado o fluxo de edição inline através de CompanyInformationEdit.

## Por que essa mudança é necessária?

O card de detalhes da empresa utilizava uma implementação própria criada antes da consolidação dos componentes compartilhados de detalhes de entidade. Esta alteração padroniza a interface com os módulos de gestor e vendedor, reduzindo inconsistências visuais, promovendo reutilização de componentes e facilitando a manutenção futura.

## Como testar?

1. Acessar a tela de detalhes de uma empresa.
2. Validar a exibição das informações da empresa (ID, Nome, CNPJ, Telefone, Endereço, Plano e Status).
3. Confirmar que o layout dos campos utiliza duas colunas em telas médias e maiores.
4. Verificar a exibição correta dos badges de plano e status.
5. Clicar em “Editar” e validar que o modo de edição continua funcionando normalmente.
6. Salvar e cancelar alterações para garantir que não houve regressão no fluxo de edição.
7. Confirmar que a navegação da tela permanece inalterada.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças