### PR TITLE
Feat/66/manager add salesman

### DIFF
--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.test.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.test.tsx
@@ -140,7 +140,13 @@ describe('AddSalesmanModal — variant admin (default)', () => {
 // ─── MANAGER ────────────────────────────────────────────────────────────────
 
 describe('AddSalesmanModal — variant manager', () => {
-  it('renders the Empresa field visible and disabled', () => {
+  it('renders the Empresa field visible and disabled when manager data is available', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
     render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
     expect(screen.getByText('Empresa')).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toBeDisabled();
@@ -197,7 +203,7 @@ describe('AddSalesmanModal — variant manager', () => {
     expect(screen.getByText('Salvar').closest('button')).toBeDisabled();
   });
 
-  it('shows an error message when manager company fails to load', () => {
+  it('shows error message in the modal body when manager query fails', () => {
     vi.mocked(useGetManagerById).mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -208,6 +214,54 @@ describe('AddSalesmanModal — variant manager', () => {
     expect(
       screen.getByText('Não foi possível carregar a empresa do gestor.')
     ).toBeInTheDocument();
+  });
+
+  it('does not render the form when manager query fails', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.queryByText('Nome do vendedor')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email de acesso')).not.toBeInTheDocument();
+  });
+
+  it('shows error message in the modal body when manager has no company', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: { ...mockManagerData, company: undefined },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(
+      screen.getByText('O gestor não possui empresa vinculada.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the form when manager has no company', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: { ...mockManagerData, company: undefined },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.queryByText('Nome do vendedor')).not.toBeInTheDocument();
+    expect(screen.queryByText('Email de acesso')).not.toBeInTheDocument();
+  });
+
+  it('disables the submit button when manager has no company', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: { ...mockManagerData, company: undefined },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.getByText('Salvar').closest('button')).toBeDisabled();
   });
 
   it("submits with company_id from manager's official company", async () => {

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.test.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.test.tsx
@@ -1,0 +1,257 @@
+import { fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@tests/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@services/queries/useCompanies', () => ({
+  useGetCompanies: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock('@services/queries/useSalesman', () => ({
+  useCreateSalesman: vi.fn(() => ({ mutate: vi.fn() })),
+}));
+
+vi.mock('@services/queries/useManagers', () => ({
+  useGetManagerById: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+vi.mock('@store/authStore', () => ({
+  useAuthStore: vi.fn((selector: (state: { user: unknown }) => unknown) =>
+    selector({
+      user: {
+        id: 'manager-uuid-1',
+        name: 'gestor',
+        email: 'gestor@empresa.com',
+        role: 'manager',
+      },
+    })
+  ),
+  selectUser: (state: { user: unknown }) => state.user,
+}));
+
+import { useGetCompanies } from '@services/queries/useCompanies';
+import { useGetManagerById } from '@services/queries/useManagers';
+import { useCreateSalesman } from '@services/queries/useSalesman';
+
+import { AddSalesmanModal } from './AddSalesmanModal';
+
+const noop = vi.fn();
+
+const mockCompanies = [
+  { id: 'c1', name: 'Empresa Alpha', active: true },
+  { id: 'c2', name: 'Empresa Beta', active: true },
+];
+
+const mockManagerData = {
+  id: 'manager-uuid-1',
+  name: 'Gestor Teste',
+  email: 'gestor@empresa.com',
+  company: { id: 'c1', name: 'Empresa Alpha' },
+  active: true,
+  preferences: null,
+};
+
+/** Fill the two plain text inputs (name + email) and click Salvar.
+ *  MUI Autocomplete renders as role="combobox", not "textbox",
+ *  so getAllByRole('textbox') gives only [name, email] for both variants. */
+const fillAndSubmit = (name: string, email: string) => {
+  const textboxes = screen.getAllByRole('textbox');
+  fireEvent.change(textboxes[0], { target: { value: name } });
+  fireEvent.change(textboxes[textboxes.length - 1], {
+    target: { value: email },
+  });
+  fireEvent.click(screen.getByText('Salvar'));
+};
+
+// ─── ADMIN (default) ────────────────────────────────────────────────────────
+
+describe('AddSalesmanModal — variant admin (default)', () => {
+  it('renders the modal title when open', () => {
+    render(<AddSalesmanModal open handleClose={noop} />);
+    expect(screen.getByText('Adicionar vendedor')).toBeInTheDocument();
+  });
+
+  it('does not render modal content when closed', () => {
+    render(<AddSalesmanModal open={false} handleClose={noop} />);
+    expect(screen.queryByText('Nome do vendedor')).not.toBeInTheDocument();
+  });
+
+  it('renders all four form fields', () => {
+    render(<AddSalesmanModal open handleClose={noop} />);
+    expect(screen.getByText('Nome do vendedor')).toBeInTheDocument();
+    expect(screen.getByText('Empresa')).toBeInTheDocument();
+    expect(screen.getByText('Email de acesso')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('shows Empresa autocomplete enabled so admin can change it', () => {
+    vi.mocked(useGetCompanies).mockReturnValue({
+      data: { content: mockCompanies },
+    } as unknown as ReturnType<typeof useGetCompanies>);
+
+    render(<AddSalesmanModal open handleClose={noop} />);
+    expect(screen.getByRole('combobox')).not.toBeDisabled();
+  });
+
+  it('shows empty-state helper text when no companies are available', () => {
+    vi.mocked(useGetCompanies).mockReturnValue({
+      data: { content: [] },
+    } as unknown as ReturnType<typeof useGetCompanies>);
+
+    render(<AddSalesmanModal open handleClose={noop} />);
+    expect(
+      screen.getByText('Nenhuma empresa disponível para vincular.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not use manager data for the company field', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="admin" />);
+    // Admin combobox must be enabled regardless of manager data
+    expect(screen.getByRole('combobox')).not.toBeDisabled();
+  });
+
+  it('submits with company object from the form selection', async () => {
+    const mockMutate = vi.fn();
+    vi.mocked(useCreateSalesman).mockReturnValue({
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useCreateSalesman>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="admin" />);
+    fillAndSubmit('João Silva', 'joao@empresa.com');
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+
+    const [submittedData] = mockMutate.mock.calls[0] as [
+      { company: { id: string } },
+    ];
+    expect(submittedData).toHaveProperty('company');
+  });
+});
+
+// ─── MANAGER ────────────────────────────────────────────────────────────────
+
+describe('AddSalesmanModal — variant manager', () => {
+  it('renders the Empresa field visible and disabled', () => {
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.getByText('Empresa')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it("pre-fills the company field with the manager's own company", async () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('Empresa Alpha')).toBeInTheDocument()
+    );
+  });
+
+  it('does not render other companies as selectable options', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+    // Even if useGetCompanies returned multiple companies, only the manager's
+    // own company should appear as an option (dropdown is disabled anyway).
+    vi.mocked(useGetCompanies).mockReturnValue({
+      data: { content: mockCompanies },
+    } as unknown as ReturnType<typeof useGetCompanies>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+
+  it('disables the submit button while manager data is loading', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.getByText('Salvar').closest('button')).toBeDisabled();
+  });
+
+  it('disables the submit button when manager company cannot be loaded', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(screen.getByText('Salvar').closest('button')).toBeDisabled();
+  });
+
+  it('shows an error message when manager company fails to load', () => {
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    expect(
+      screen.getByText('Não foi possível carregar a empresa do gestor.')
+    ).toBeInTheDocument();
+  });
+
+  it("submits with company_id from manager's official company", async () => {
+    const mockMutate = vi.fn();
+    vi.mocked(useCreateSalesman).mockReturnValue({
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useCreateSalesman>);
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(<AddSalesmanModal open handleClose={noop} variant="manager" />);
+    fillAndSubmit('João Silva', 'joao@empresa.com');
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+
+    const [submittedData] = mockMutate.mock.calls[0] as [
+      { company: { id: string } },
+    ];
+    // useCreateSalesman maps company.id → company_id in the API payload
+    expect(submittedData.company.id).toBe('c1');
+  });
+
+  it('calls handleClose on successful creation', async () => {
+    const handleClose = vi.fn();
+    const mockMutate = vi.fn().mockImplementation((_data, options) => {
+      options?.onSuccess?.();
+    });
+    vi.mocked(useCreateSalesman).mockReturnValue({
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useCreateSalesman>);
+    vi.mocked(useGetManagerById).mockReturnValue({
+      data: mockManagerData,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useGetManagerById>);
+
+    render(
+      <AddSalesmanModal open handleClose={handleClose} variant="manager" />
+    );
+    fillAndSubmit('João Silva', 'joao@empresa.com');
+
+    await waitFor(() => expect(handleClose).toHaveBeenCalled());
+  });
+});

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
@@ -9,6 +9,7 @@ import {
 import {
   CreateSalesmanSchema,
   type TCreateSalesman,
+  type TSalesmanCompany,
 } from '@services/models/SalesmanSchema';
 import { useGetCompanies } from '@services/queries/useCompanies';
 import { useGetManagerById } from '@services/queries/useManagers';
@@ -18,8 +19,6 @@ import { AppModal } from '@UI/AppModal/AppModal';
 import type { JSX } from 'react';
 import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-
-type CompanyOption = { id: string; name: string };
 
 export interface IAddSalesmanModalProps {
   open: boolean;
@@ -62,7 +61,7 @@ export const AddSalesmanModal = ({
     isError: isManagerError,
   } = useGetManagerById(isManagerVariant ? (user?.id ?? null) : null);
 
-  const companyOptions: CompanyOption[] = isManagerVariant
+  const companyOptions: TSalesmanCompany[] = isManagerVariant
     ? managerData?.company
       ? [managerData.company]
       : []
@@ -154,7 +153,7 @@ export const AddSalesmanModal = ({
             name="company"
             control={control}
             render={({ field }) => (
-              <Autocomplete<CompanyOption, false, false, false>
+              <Autocomplete<TSalesmanCompany, false, false, false>
                 disablePortal
                 disabled={isManagerVariant}
                 options={companyOptions}

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
@@ -6,32 +6,40 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import type { TCompany } from '@services/models/CompanySchema';
 import {
   CreateSalesmanSchema,
   type TCreateSalesman,
 } from '@services/models/SalesmanSchema';
 import { useGetCompanies } from '@services/queries/useCompanies';
+import { useGetManagerById } from '@services/queries/useManagers';
 import { useCreateSalesman } from '@services/queries/useSalesman';
+import { selectUser, useAuthStore } from '@store/authStore';
 import { AppModal } from '@UI/AppModal/AppModal';
 import type { JSX } from 'react';
 import { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+type CompanyOption = { id: string; name: string };
+
 export interface IAddSalesmanModalProps {
   open: boolean;
   handleClose: () => void;
+  variant?: 'admin' | 'manager';
 }
 
 export const AddSalesmanModal = ({
   open,
   handleClose,
+  variant = 'admin',
 }: IAddSalesmanModalProps): JSX.Element => {
+  const isManagerVariant = variant === 'manager';
+
   const {
     control,
     handleSubmit,
     formState: { errors },
     reset,
+    setValue,
   } = useForm<TCreateSalesman>({
     resolver: zodResolver(CreateSalesmanSchema),
     defaultValues: {
@@ -42,16 +50,36 @@ export const AddSalesmanModal = ({
     },
   });
 
+  // ADMIN: fetch all companies via the admin-scoped endpoint.
   const { data: companiesPage } = useGetCompanies();
-  const companyOptions: TCompany[] = (companiesPage?.content ?? []).filter(
-    (c) => c.active
-  );
+
+  // MANAGER: fetch the authenticated manager's own record to get the official company.
+  // useGetManagerById is a no-op when uuid is null (enabled: !!uuid).
+  const user = useAuthStore(selectUser);
+  const {
+    data: managerData,
+    isLoading: isManagerLoading,
+    isError: isManagerError,
+  } = useGetManagerById(isManagerVariant ? (user?.id ?? null) : null);
+
+  const companyOptions: CompanyOption[] = isManagerVariant
+    ? managerData?.company
+      ? [managerData.company]
+      : []
+    : (companiesPage?.content ?? []).filter((c) => c.active);
 
   useEffect(() => {
     if (!open) {
       reset();
     }
   }, [open, reset]);
+
+  // Manager: pre-fill the company field once the manager record loads.
+  useEffect(() => {
+    if (isManagerVariant && managerData?.company) {
+      setValue('company', managerData.company);
+    }
+  }, [isManagerVariant, managerData?.company, setValue]);
 
   const { mutate: createSalesman } = useCreateSalesman();
 
@@ -63,13 +91,30 @@ export const AddSalesmanModal = ({
     });
   };
 
+  const getCompanyHelperText = (): string | undefined => {
+    if (errors.company?.message) return errors.company.message;
+    if (isManagerVariant) {
+      if (isManagerError)
+        return 'Não foi possível carregar a empresa do gestor.';
+      if (!isManagerLoading && companyOptions.length === 0)
+        return 'Nenhuma empresa disponível para vincular.';
+      return undefined;
+    }
+    if (companyOptions.length === 0)
+      return 'Nenhuma empresa disponível para vincular.';
+    return undefined;
+  };
+
   return (
     <AppModal
       modalName="Adicionar vendedor"
       open={open}
       handleClose={handleClose}
       handleSubmit={handleSubmit(onSubmit)}
-      isSaveButtonDisabled={false}
+      isSaveButtonDisabled={
+        isManagerVariant &&
+        (isManagerLoading || isManagerError || !managerData?.company)
+      }
     >
       <Box
         sx={{
@@ -109,8 +154,9 @@ export const AddSalesmanModal = ({
             name="company"
             control={control}
             render={({ field }) => (
-              <Autocomplete<TCompany, false, false, false>
+              <Autocomplete<CompanyOption, false, false, false>
                 disablePortal
+                disabled={isManagerVariant}
                 options={companyOptions}
                 getOptionLabel={(option) => option.name}
                 isOptionEqualToValue={(a, b) => a.id === b.id}
@@ -126,13 +172,10 @@ export const AddSalesmanModal = ({
                     {...params}
                     name={field.name}
                     inputRef={field.ref}
-                    error={!!errors.company}
-                    helperText={
-                      errors.company?.message ??
-                      (companyOptions.length === 0
-                        ? 'Nenhuma empresa disponível para vincular.'
-                        : undefined)
+                    error={
+                      !!errors.company || (isManagerVariant && isManagerError)
                     }
+                    helperText={getCompanyHelperText()}
                   />
                 )}
               />

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  Alert,
   Autocomplete,
   Box,
   Switch,
@@ -92,17 +93,21 @@ export const AddSalesmanModal = ({
 
   const getCompanyHelperText = (): string | undefined => {
     if (errors.company?.message) return errors.company.message;
-    if (isManagerVariant) {
-      if (isManagerError)
-        return 'Não foi possível carregar a empresa do gestor.';
-      if (!isManagerLoading && companyOptions.length === 0)
-        return 'Nenhuma empresa disponível para vincular.';
-      return undefined;
-    }
-    if (companyOptions.length === 0)
+    if (!isManagerVariant && companyOptions.length === 0)
       return 'Nenhuma empresa disponível para vincular.';
     return undefined;
   };
+
+  // Manager blocking states: failed query or successful load with no company.
+  // In either case the form must not be rendered as usable.
+  const showManagerBlockingError =
+    isManagerVariant &&
+    !isManagerLoading &&
+    (isManagerError || !managerData?.company);
+
+  const managerErrorMessage = isManagerError
+    ? 'Não foi possível carregar a empresa do gestor.'
+    : 'O gestor não possui empresa vinculada.';
 
   return (
     <AppModal
@@ -115,132 +120,147 @@ export const AddSalesmanModal = ({
         (isManagerLoading || isManagerError || !managerData?.company)
       }
     >
-      <Box
-        sx={{
-          width: '100%',
-          boxSizing: 'border-box',
-          padding: '48px',
-          marginBottom: '48px',
-          display: 'grid',
-          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
-          columnGap: '32px',
-          rowGap: '32px',
-        }}
-      >
-        <Box>
-          <Typography sx={{ mb: 1 }} variant="body2">
-            Nome do vendedor
-          </Typography>
-          <Controller
-            name="name"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                fullWidth
-                error={!!errors.name}
-                helperText={errors.name?.message}
-              />
-            )}
-          />
+      {showManagerBlockingError ? (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '48px',
+            minHeight: 200,
+          }}
+        >
+          <Alert severity="error" sx={{ width: '100%' }}>
+            {managerErrorMessage}
+          </Alert>
         </Box>
-
-        <Box>
-          <Typography sx={{ mb: 1 }} variant="body2">
-            Empresa
-          </Typography>
-          <Controller
-            name="company"
-            control={control}
-            render={({ field }) => (
-              <Autocomplete<TSalesmanCompany, false, false, false>
-                disablePortal
-                disabled={isManagerVariant}
-                options={companyOptions}
-                getOptionLabel={(option) => option.name}
-                isOptionEqualToValue={(a, b) => a.id === b.id}
-                value={
-                  companyOptions.find((c) => c.id === field.value?.id) ?? null
-                }
-                onChange={(_, company) => {
-                  field.onChange(company ?? null);
-                }}
-                onBlur={field.onBlur}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    name={field.name}
-                    inputRef={field.ref}
-                    error={
-                      !!errors.company || (isManagerVariant && isManagerError)
-                    }
-                    helperText={getCompanyHelperText()}
-                  />
-                )}
-              />
-            )}
-          />
-        </Box>
-
-        <Box>
-          <Typography sx={{ mb: 1 }} variant="body2">
-            Email de acesso
-          </Typography>
-          <Controller
-            name="email"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                fullWidth
-                type="email"
-                error={!!errors.email}
-                helperText={errors.email?.message}
-              />
-            )}
-          />
-        </Box>
-
-        <Box>
-          <Typography sx={{ mb: 1 }} variant="body2">
-            Status
-          </Typography>
-          <Controller
-            name="active"
-            control={control}
-            render={({ field }) => (
-              <Box
-                sx={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '12px',
-                }}
-              >
-                <Typography variant="body2">
-                  {field.value ? 'Ativo' : 'Inativo'}
-                </Typography>
-                <Switch
+      ) : (
+        <Box
+          sx={{
+            width: '100%',
+            boxSizing: 'border-box',
+            padding: '48px',
+            marginBottom: '48px',
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+            columnGap: '32px',
+            rowGap: '32px',
+          }}
+        >
+          <Box>
+            <Typography sx={{ mb: 1 }} variant="body2">
+              Nome do vendedor
+            </Typography>
+            <Controller
+              name="name"
+              control={control}
+              render={({ field }) => (
+                <TextField
                   {...field}
-                  checked={field.value}
-                  sx={{
-                    '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#2E7D32',
-                    },
-                    '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                      backgroundColor: '#2E7D32',
-                    },
-                  }}
-                  slotProps={{
-                    input: {
-                      'aria-label': 'status do vendedor',
-                    },
-                  }}
+                  fullWidth
+                  error={!!errors.name}
+                  helperText={errors.name?.message}
                 />
-              </Box>
-            )}
-          />
+              )}
+            />
+          </Box>
+
+          <Box>
+            <Typography sx={{ mb: 1 }} variant="body2">
+              Empresa
+            </Typography>
+            <Controller
+              name="company"
+              control={control}
+              render={({ field }) => (
+                <Autocomplete<TSalesmanCompany, false, false, false>
+                  disablePortal
+                  disabled={isManagerVariant}
+                  options={companyOptions}
+                  getOptionLabel={(option) => option.name}
+                  isOptionEqualToValue={(a, b) => a.id === b.id}
+                  value={
+                    companyOptions.find((c) => c.id === field.value?.id) ?? null
+                  }
+                  onChange={(_, company) => {
+                    field.onChange(company ?? null);
+                  }}
+                  onBlur={field.onBlur}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      name={field.name}
+                      inputRef={field.ref}
+                      error={!!errors.company}
+                      helperText={getCompanyHelperText()}
+                    />
+                  )}
+                />
+              )}
+            />
+          </Box>
+
+          <Box>
+            <Typography sx={{ mb: 1 }} variant="body2">
+              Email de acesso
+            </Typography>
+            <Controller
+              name="email"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  fullWidth
+                  type="email"
+                  error={!!errors.email}
+                  helperText={errors.email?.message}
+                />
+              )}
+            />
+          </Box>
+
+          <Box>
+            <Typography sx={{ mb: 1 }} variant="body2">
+              Status
+            </Typography>
+            <Controller
+              name="active"
+              control={control}
+              render={({ field }) => (
+                <Box
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '12px',
+                  }}
+                >
+                  <Typography variant="body2">
+                    {field.value ? 'Ativo' : 'Inativo'}
+                  </Typography>
+                  <Switch
+                    {...field}
+                    checked={field.value}
+                    sx={{
+                      '& .MuiSwitch-switchBase.Mui-checked': {
+                        color: '#2E7D32',
+                      },
+                      '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track':
+                        {
+                          backgroundColor: '#2E7D32',
+                        },
+                    }}
+                    slotProps={{
+                      input: {
+                        'aria-label': 'status do vendedor',
+                      },
+                    }}
+                  />
+                </Box>
+              )}
+            />
+          </Box>
         </Box>
-      </Box>
+      )}
     </AppModal>
   );
 };

--- a/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.test.tsx
+++ b/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.test.tsx
@@ -8,7 +8,8 @@ vi.mock('@services/queries/useSalesmen', () => ({
 }));
 
 vi.mock('../AddSalesmanModal/AddSalesmanModal', () => ({
-  AddSalesmanModal: () => <div data-testid="add-salesman-modal" />,
+  AddSalesmanModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="add-salesman-modal" /> : null,
 }));
 
 import { useGetSalesmen } from '@services/queries/useSalesmen';
@@ -155,8 +156,16 @@ describe('ManagerSalesmenPage', () => {
     expect(screen.getByText('carlos@outra.com')).toBeInTheDocument();
   });
 
-  it('renders the AddSalesmanModal', () => {
+  it('modal is closed by default', () => {
     render(<ManagerSalesmenPage />);
+    expect(screen.queryByTestId('add-salesman-modal')).not.toBeInTheDocument();
+  });
+
+  it('opens AddSalesmanModal when add salesman button is clicked', () => {
+    render(<ManagerSalesmenPage />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /adicionar vendedor/i })
+    );
     expect(screen.getByTestId('add-salesman-modal')).toBeInTheDocument();
   });
 

--- a/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
+++ b/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
@@ -82,7 +82,7 @@ export const ManagerSalesmenPage = (): JSX.Element => {
           <Button
             startIcon={<AddIcon />}
             variant="gradient"
-            // TODO: Implementar funcionalidade de adicionar vendedor (FE-28)
+            onClick={() => setIsModalOpen(true)}
           >
             Adicionar vendedor
           </Button>
@@ -142,6 +142,7 @@ export const ManagerSalesmenPage = (): JSX.Element => {
       <AddSalesmanModal
         open={isModalOpen}
         handleClose={() => setIsModalOpen(false)}
+        variant="manager"
       />
     </PageContainter>
   );

--- a/src/services/models/SalesmanSchema.ts
+++ b/src/services/models/SalesmanSchema.ts
@@ -163,6 +163,7 @@ export const SalesmanFiltersSchema = z.object({
   active: z.boolean().optional(),
 });
 
+export type TSalesmanCompany = z.infer<typeof SalesmanCompanySchema>;
 export type TSalesman = z.infer<typeof SalesmanSchema>;
 export type TCreateSalesman = z.infer<typeof CreateSalesmanSchema>;
 export type TSalesmanWithCompany = z.infer<typeof SalesmanListItemSchema>;


### PR DESCRIPTION
## Issue relacionada
#66 

## O que foi implementado?

### Fluxo de criação de vendedores para GESTOR
* Integração do botão “Adicionar vendedor” na ManagerSalesmenPage.
* Abertura do AddSalesmanModal a partir da tela de vendedores do gestor.
* Adição do suporte a variantes no modal **(admin e manager)**, preservando o comportamento existente do ADMIN.
* Campo Empresa mantido visível para o gestor e configurado como não editável.
* Bloqueio do envio do formulário enquanto a empresa vinculada ao gestor não estiver disponível.
* Exibição de mensagens de erro quando não for possível carregar os dados necessários para o cadastro.

### Testes
* Atualização dos testes da ManagerSalesmenPage.
* Criação/atualização dos testes do AddSalesmanModal.
* Cobertura dos comportamentos específicos de ADMIN e MANAGER.
* Todos os testes do projeto permanecem passando (332/332).

### Investigação técnica realizada
Durante a implementação foi identificado um bloqueio relacionado ao carregamento da empresa vinculada ao gestor autenticado.

**Foi realizada uma investigação dos contratos do frontend e backend, incluindo:**
* JWT emitido pela autenticação;
* endpoints de empresas;
* endpoints de gestores;
* regras de autorização dos controllers;
* validações de acesso utilizadas pelo backend.

**Foi confirmado que:**
* o JWT já contém o campo company_id;
* o frontend atualmente não consome essa claim;
* os endpoints de empresa e gestor são restritos ao papel ADMIN;
* não existe endpoint acessível ao MANAGER para consultar sua própria empresa;
* o frontend não possui atualmente uma fonte autorizada para obter o nome da empresa vinculada ao gestor.

## Por que essa mudança é necessária?
O módulo GESTOR precisava permitir o início do fluxo de criação de vendedores, mantendo as restrições de acesso do papel MANAGER e evitando exposição de empresas fora do seu escopo.

## Diagnóstico

Durante a implementação também foi identificado um desalinhamento contratual entre frontend e backend. O backend já disponibiliza company_id no JWT, porém não disponibiliza atualmente uma forma autorizada para que o MANAGER obtenha o nome da sua empresa (obter o nome da empresa associada ao usuário autenticado).

**Possíveis soluções futuras para serem discutidas com o time:**
* inclusão de company_name no JWT;
* criação de um endpoint /me para consulta do usuário autenticado;
* liberação de self-access para consulta do próprio gestor.

A conclusão da integração completa do fluxo de criação de vendedores pelo MANAGER depende da definição de uma dessas alternativas no backend.

## Como testar?

1. Acesse o sistema com um usuário MANAGER.
2. Navegue até a tela de vendedores.
3. Clique em Adicionar vendedor.
4. Verifique a abertura do modal e o comportamento específico do gestor.
5. Verifique a exibição das mensagens de erro quando os dados da empresa não puderem ser carregados.
6. Execute os testes automatizados: `pnpm test`

## Checklist
- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [X] Testes foram adicionados ou atualizados para cobrir as mudanças