### PR TITLE
FE-30 painel vendedor

### DIFF
--- a/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
@@ -9,6 +9,7 @@ import { MeetingsByChart } from '@pages/DashboardPage/components/MeetingsByChart
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
 import { useDashboardFilterContext } from '@pages/DashboardPage/context/DashboardFilterContext';
 import {
+  type TDashboardMetric,
   type TDashboardMetricKey,
   type TDashboardMetrics,
 } from '@services/models/DashboardSchema';
@@ -59,7 +60,7 @@ const metricCardConfig: readonly TMetricCardConfig[] = [
 const getMetricValue = (
   metrics: TDashboardMetrics | undefined,
   metricKey: TDashboardMetricKey
-): TDashboardMetrics[TDashboardMetricKey] =>
+): TDashboardMetric =>
   metrics?.[metricKey] ?? {
     value: 0,
     variationPercentage: 0,

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
@@ -93,5 +93,7 @@ describe('SalesmanDashboard', () => {
     expect(screen.getByText(ECardLabel.AVERAGE_FEELING)).toBeInTheDocument();
     expect(screen.getByText('40 min')).toBeInTheDocument();
     expect(screen.getByText('90%')).toBeInTheDocument();
+    expect(screen.queryByText('+12%')).not.toBeInTheDocument();
+    expect(screen.queryByText('+8%')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
@@ -54,6 +54,11 @@ describe('SalesmanDashboard', () => {
           variationPercentage: 8,
           trend: 'up',
         },
+        average_sentiment: {
+          value: 90,
+          variationPercentage: 0,
+          trend: 'neutral',
+        },
       },
       isError: false,
       isLoading: false,

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.test.tsx
@@ -1,6 +1,7 @@
+import { ECardLabel } from '@data/enums/ECardLabel';
 import { EPageTitles } from '@data/enums/EPageTitles';
 import { render, screen } from '@tests/testUtils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@pages/DashboardPage/context/DashboardFilterContext', () => ({
   useDashboardFilterContext: () => ({
@@ -12,13 +13,85 @@ vi.mock('@pages/DashboardPage/context/DashboardFilterContext', () => ({
   }),
 }));
 
+vi.mock('@services/queries/useDashboard', () => ({
+  useGetDashboardMetrics: vi.fn(),
+  useGetMeetingsByMonth: vi.fn(),
+}));
+
+vi.mock('@store/hooks/useDashboardAvgDuration', () => ({
+  useDashboardAvgDuration: vi.fn(),
+}));
+
+import {
+  useGetDashboardMetrics,
+  useGetMeetingsByMonth,
+} from '@services/queries/useDashboard';
+import { useDashboardAvgDuration } from '@store/hooks/useDashboardAvgDuration';
+
 import { SalesmanDashboard } from './SalesmanDashboard';
 
+const mockUseGetDashboardMetrics = useGetDashboardMetrics as ReturnType<
+  typeof vi.fn
+>;
+const mockUseGetMeetingsByMonth = useGetMeetingsByMonth as ReturnType<
+  typeof vi.fn
+>;
+const mockUseDashboardAvgDuration = useDashboardAvgDuration as ReturnType<
+  typeof vi.fn
+>;
+
 describe('SalesmanDashboard', () => {
+  beforeEach(() => {
+    mockUseGetDashboardMetrics.mockReturnValue({
+      data: {
+        total_meetings: {
+          value: 18,
+          variationPercentage: 12,
+          trend: 'up',
+        },
+        average_duration: {
+          value: 2400,
+          variationPercentage: 8,
+          trend: 'up',
+        },
+      },
+      isError: false,
+      isLoading: false,
+    });
+    mockUseGetMeetingsByMonth.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
   it('renders salesman dashboard title', () => {
     render(<SalesmanDashboard />);
     expect(
       screen.getByText(EPageTitles.SALESMAN_DASHBOARD)
     ).toBeInTheDocument();
+  });
+
+  it('renders salesman metric cards', () => {
+    render(<SalesmanDashboard />);
+
+    expect(
+      screen.getByTestId('salesman-dashboard-metric-card-total_meetings')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('salesman-dashboard-metric-card-average_duration')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('salesman-dashboard-metric-card-average_sentiment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(ECardLabel.AVERAGE_DURATION)).toBeInTheDocument();
+    expect(screen.getByText(ECardLabel.AVERAGE_FEELING)).toBeInTheDocument();
+    expect(screen.getByText('40 min')).toBeInTheDocument();
+    expect(screen.getByText('90%')).toBeInTheDocument();
   });
 });

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
@@ -3,6 +3,7 @@ import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
 import type { TColorThemeOptions } from '@declarations/hooks';
 import type { TIconName } from '@declarations/ui';
+import { getSentimentConfig } from '@hooks/useSentiment';
 import { Box, Grid, Stack } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
 import { formatDurationSecondsAsMinutes } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils';
@@ -33,8 +34,6 @@ const defaultMetric: TDashboardMetric = {
   trend: 'neutral',
 };
 
-const mockedAverageSentiment = 90;
-
 const metricCardConfig: readonly TSalesmanMetricCardConfig[] = [
   {
     key: 'total_meetings',
@@ -54,12 +53,17 @@ const metricCardConfig: readonly TSalesmanMetricCardConfig[] = [
 
 const getMetricValue = (
   metrics: TDashboardMetrics | undefined,
-  metricKey: TSalesmanMetricCardConfig['key']
+  metricKey: TDashboardMetricKey
 ): TDashboardMetric => metrics?.[metricKey] ?? defaultMetric;
 
 export const SalesmanDashboard = (): JSX.Element => {
   const { filters } = useDashboardFilterContext();
   const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
+  const averageSentiment = getMetricValue(
+    dashboardMetrics,
+    'average_sentiment'
+  );
+  const sentimentConfig = getSentimentConfig(averageSentiment.value);
 
   return (
     <PageContainter>
@@ -94,9 +98,9 @@ export const SalesmanDashboard = (): JSX.Element => {
             data-testid="salesman-dashboard-metric-card-average_sentiment"
           >
             <StatCard
-              iconName="sentimentHappy"
-              theme="success"
-              value={`${mockedAverageSentiment}%`}
+              iconName={sentimentConfig.iconName}
+              theme={sentimentConfig.theme}
+              value={`${averageSentiment.value}%`}
               label={ECardLabel.AVERAGE_FEELING}
             />
           </Grid>

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
@@ -3,9 +3,9 @@ import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
 import type { TColorThemeOptions } from '@declarations/hooks';
 import type { TIconName } from '@declarations/ui';
-import { Box, Stack, useTheme } from '@mui/material';
+import { Box, Grid, Stack } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
-import { InsightChip } from '@pages/DashboardPage/components/InsightChip/InsightChip';
+import { formatDurationSecondsAsMinutes } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils';
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
 import { useDashboardFilterContext } from '@pages/DashboardPage/context/DashboardFilterContext';
 import type {
@@ -35,9 +35,6 @@ const defaultMetric: TDashboardMetric = {
 
 const mockedAverageSentiment = 90;
 
-const formatAverageDuration = (durationSeconds: number): string =>
-  `${Math.round(durationSeconds / 60)} min`;
-
 const metricCardConfig: readonly TSalesmanMetricCardConfig[] = [
   {
     key: 'total_meetings',
@@ -51,7 +48,7 @@ const metricCardConfig: readonly TSalesmanMetricCardConfig[] = [
     iconName: 'duration',
     iconTheme: 'neutrals',
     label: ECardLabel.AVERAGE_DURATION,
-    formatValue: formatAverageDuration,
+    formatValue: formatDurationSecondsAsMinutes,
   },
 ];
 
@@ -61,7 +58,6 @@ const getMetricValue = (
 ): TDashboardMetric => metrics?.[metricKey] ?? defaultMetric;
 
 export const SalesmanDashboard = (): JSX.Element => {
-  const { spacing } = useTheme();
   const { filters } = useDashboardFilterContext();
   const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
 
@@ -73,25 +69,15 @@ export const SalesmanDashboard = (): JSX.Element => {
           subtitle={EpageDescriptions.SALESMAN_DASHBOARD}
         />
 
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: 'repeat(2, minmax(0, 1fr))',
-              lg: 'repeat(3, minmax(0, 1fr))',
-            },
-            gap: 2,
-          }}
-        >
+        <Grid container spacing={2}>
           {metricCardConfig.map((config) => {
             const metric = getMetricValue(dashboardMetrics, config.key);
 
             return (
-              <Box
+              <Grid
                 key={config.key}
+                size={{ xs: 12, sm: 6, lg: 4 }}
                 data-testid={`salesman-dashboard-metric-card-${config.key}`}
-                sx={{ position: 'relative' }}
               >
                 <StatCard
                   iconName={config.iconName}
@@ -99,28 +85,22 @@ export const SalesmanDashboard = (): JSX.Element => {
                   value={config.formatValue(metric.value)}
                   label={config.label}
                 />
-                <InsightChip
-                  variationPercentage={metric.variationPercentage}
-                  trend={metric.trend}
-                  sx={{
-                    position: 'absolute',
-                    top: spacing(3),
-                    right: spacing(3),
-                  }}
-                />
-              </Box>
+              </Grid>
             );
           })}
 
-          <Box data-testid="salesman-dashboard-metric-card-average_sentiment">
+          <Grid
+            size={{ xs: 12, sm: 6, lg: 4 }}
+            data-testid="salesman-dashboard-metric-card-average_sentiment"
+          >
             <StatCard
               iconName="sentimentHappy"
               theme="success"
               value={`${mockedAverageSentiment}%`}
               label={ECardLabel.AVERAGE_FEELING}
             />
-          </Box>
-        </Box>
+          </Grid>
+        </Grid>
 
         <Stack
           direction={{ xs: 'column', md: 'row' }}

--- a/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
+++ b/src/pages/DashboardPage/SalesmanDashboard/SalesmanDashboard.tsx
@@ -1,21 +1,132 @@
+import { ECardLabel } from '@data/enums/ECardLabel';
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { Box, Stack } from '@mui/material';
+import type { TColorThemeOptions } from '@declarations/hooks';
+import type { TIconName } from '@declarations/ui';
+import { Box, Stack, useTheme } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
+import { InsightChip } from '@pages/DashboardPage/components/InsightChip/InsightChip';
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
+import { useDashboardFilterContext } from '@pages/DashboardPage/context/DashboardFilterContext';
+import type {
+  TDashboardMetric,
+  TDashboardMetricKey,
+  TDashboardMetrics,
+} from '@services/models/DashboardSchema';
+import { useGetDashboardMetrics } from '@services/queries/useDashboard';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
+import { StatCard } from '@UI/StatCard/StatCard';
 import type { JSX } from 'react';
 
+type TSalesmanMetricCardConfig = {
+  key: Extract<TDashboardMetricKey, 'total_meetings' | 'average_duration'>;
+  iconName: TIconName;
+  iconTheme: TColorThemeOptions;
+  label: (typeof ECardLabel)[keyof typeof ECardLabel];
+  formatValue: (value: number) => string | number;
+};
+
+const defaultMetric: TDashboardMetric = {
+  value: 0,
+  variationPercentage: 0,
+  trend: 'neutral',
+};
+
+const mockedAverageSentiment = 90;
+
+const formatAverageDuration = (durationSeconds: number): string =>
+  `${Math.round(durationSeconds / 60)} min`;
+
+const metricCardConfig: readonly TSalesmanMetricCardConfig[] = [
+  {
+    key: 'total_meetings',
+    iconName: 'meeting',
+    iconTheme: 'meetings',
+    label: ECardLabel.TOTAL_MEETINGS,
+    formatValue: (value) => value,
+  },
+  {
+    key: 'average_duration',
+    iconName: 'duration',
+    iconTheme: 'neutrals',
+    label: ECardLabel.AVERAGE_DURATION,
+    formatValue: formatAverageDuration,
+  },
+];
+
+const getMetricValue = (
+  metrics: TDashboardMetrics | undefined,
+  metricKey: TSalesmanMetricCardConfig['key']
+): TDashboardMetric => metrics?.[metricKey] ?? defaultMetric;
+
 export const SalesmanDashboard = (): JSX.Element => {
+  const { spacing } = useTheme();
+  const { filters } = useDashboardFilterContext();
+  const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
+
   return (
     <PageContainter>
-      <Stack spacing={4} sx={{ width: '100%' }}>
+      <Stack spacing={3} sx={{ width: '100%' }}>
         <PageHeader
           title={EPageTitles.SALESMAN_DASHBOARD}
           subtitle={EpageDescriptions.SALESMAN_DASHBOARD}
         />
-        <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, minmax(0, 1fr))',
+              lg: 'repeat(3, minmax(0, 1fr))',
+            },
+            gap: 2,
+          }}
+        >
+          {metricCardConfig.map((config) => {
+            const metric = getMetricValue(dashboardMetrics, config.key);
+
+            return (
+              <Box
+                key={config.key}
+                data-testid={`salesman-dashboard-metric-card-${config.key}`}
+                sx={{ position: 'relative' }}
+              >
+                <StatCard
+                  iconName={config.iconName}
+                  theme={config.iconTheme}
+                  value={config.formatValue(metric.value)}
+                  label={config.label}
+                />
+                <InsightChip
+                  variationPercentage={metric.variationPercentage}
+                  trend={metric.trend}
+                  sx={{
+                    position: 'absolute',
+                    top: spacing(3),
+                    right: spacing(3),
+                  }}
+                />
+              </Box>
+            );
+          })}
+
+          <Box data-testid="salesman-dashboard-metric-card-average_sentiment">
+            <StatCard
+              iconName="sentimentHappy"
+              theme="success"
+              value={`${mockedAverageSentiment}%`}
+              label={ECardLabel.AVERAGE_FEELING}
+            />
+          </Box>
+        </Box>
+
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={2}
+          sx={{ width: '100%' }}
+        >
           <Box sx={{ flex: 1, minWidth: 0, height: '100%' }}>
             <MeetingsByMonthChart />
           </Box>

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.test.tsx
@@ -4,7 +4,11 @@ import { render, screen } from '@tests/testUtils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AvgDurationLineChart } from './AvgDurationLineChart';
-import { formatDuration, formatMonthLabel } from './AvgDurationLineChart.utils';
+import {
+  formatDuration,
+  formatDurationSecondsAsMinutes,
+  formatMonthLabel,
+} from './AvgDurationLineChart.utils';
 
 const mockUseDashboardAvgDuration = vi.fn();
 
@@ -39,6 +43,12 @@ describe('AvgDurationLineChart', () => {
     expect(formatDuration(158)).toBe('2 horas e 38 minutos');
     expect(formatDuration(38.4)).toBe('38 minutos');
     expect(formatDuration(38.6)).toBe('39 minutos');
+  });
+
+  it('formats duration seconds as short minutes', () => {
+    expect(formatDurationSecondsAsMinutes(0)).toBe('0 min');
+    expect(formatDurationSecondsAsMinutes(90)).toBe('2 min');
+    expect(formatDurationSecondsAsMinutes(2400)).toBe('40 min');
   });
 
   it('renders loading state', () => {

--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils.ts
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.utils.ts
@@ -42,3 +42,11 @@ export const formatDuration = (value: number): string => {
 
   return `${hourText} e ${pluralize(minutes, 'minuto', 'minutos')}`;
 };
+
+export const formatDurationSecondsAsMinutes = (
+  durationSeconds: number
+): string => {
+  const roundedMinutes = Math.max(0, Math.round(durationSeconds / 60));
+
+  return `${roundedMinutes} min`;
+};

--- a/src/services/api/dashboard.test.ts
+++ b/src/services/api/dashboard.test.ts
@@ -85,6 +85,26 @@ describe('dashboardApi', () => {
     });
   });
 
+  it('parses seller dashboard metrics', async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        total_meetings: { value: 15, variation_percent: 20, trend: 'up' },
+        average_duration: {
+          value: 2400,
+          variation_percent: -5,
+          trend: 'down',
+        },
+      },
+    });
+
+    const metrics = await dashboardApi.getMetrics({ period: '30d' });
+
+    expect(metrics.total_meetings?.value).toBe(15);
+    expect(metrics.total_meetings?.variationPercentage).toBe(20);
+    expect(metrics.average_duration?.value).toBe(2400);
+    expect(metrics.average_duration?.trend).toBe('down');
+  });
+
   it('sends custom range params when fetching avg duration', async () => {
     mockedGet.mockResolvedValue({
       data: {

--- a/src/services/models/DashboardSchema.ts
+++ b/src/services/models/DashboardSchema.ts
@@ -20,6 +20,8 @@ export const DashboardMetricTrendSchema = z.enum(['up', 'down', 'neutral']);
 export const DashboardMetricKeySchema = z.enum([
   'active_companies',
   'inactive_companies',
+  'average_duration',
+  'average_sentiment',
   'total_meetings',
   'salesmen',
 ]);
@@ -63,29 +65,52 @@ const DashboardMetricApiSchema = z
     };
   });
 
+export type TDashboardMetric = z.infer<typeof DashboardMetricApiSchema>;
+export type TDashboardMetrics = Partial<
+  Record<TDashboardMetricKey, TDashboardMetric>
+>;
+
+const assignMetric = (
+  metrics: TDashboardMetrics,
+  key: TDashboardMetricKey,
+  metric?: TDashboardMetric
+): void => {
+  if (metric) {
+    metrics[key] = metric;
+  }
+};
+
 export const DashboardMetricsResponseSchema = z
   .object({
-    active_companies: DashboardMetricApiSchema,
-    inactive_companies: DashboardMetricApiSchema,
-    total_meetings: DashboardMetricApiSchema,
-    active_sellers: DashboardMetricApiSchema,
+    active_companies: DashboardMetricApiSchema.optional(),
+    inactive_companies: DashboardMetricApiSchema.optional(),
+    average_duration: DashboardMetricApiSchema.optional(),
+    average_sentiment: DashboardMetricApiSchema.optional(),
+    total_meetings: DashboardMetricApiSchema.optional(),
+    active_sellers: DashboardMetricApiSchema.optional(),
+    salesmen: DashboardMetricApiSchema.optional(),
   })
-  .transform((r) => ({
-    active_companies: r.active_companies,
-    inactive_companies: r.inactive_companies,
-    total_meetings: r.total_meetings,
-    salesmen: r.active_sellers,
-  }));
+  .transform((response) => {
+    const metrics: TDashboardMetrics = {};
 
-export const DashboardMetricsSchema = z.object({
-  active_companies: DashboardMetricApiSchema,
-  inactive_companies: DashboardMetricApiSchema,
-  total_meetings: DashboardMetricApiSchema,
-  salesmen: DashboardMetricApiSchema,
-});
+    assignMetric(metrics, 'active_companies', response.active_companies);
+    assignMetric(metrics, 'inactive_companies', response.inactive_companies);
+    assignMetric(metrics, 'average_duration', response.average_duration);
+    assignMetric(metrics, 'average_sentiment', response.average_sentiment);
+    assignMetric(metrics, 'total_meetings', response.total_meetings);
+    assignMetric(
+      metrics,
+      'salesmen',
+      response.active_sellers ?? response.salesmen
+    );
 
-export type TDashboardMetric = z.infer<typeof DashboardMetricApiSchema>;
-export type TDashboardMetrics = z.infer<typeof DashboardMetricsSchema>;
+    return metrics;
+  });
+
+export const DashboardMetricsSchema = z.partialRecord(
+  DashboardMetricKeySchema,
+  DashboardMetricApiSchema
+);
 
 const MeetingsByCompanyItemApiSchema = z.object({
   company_name: z.string().trim().min(1),

--- a/src/services/models/DashboardSchema.ts
+++ b/src/services/models/DashboardSchema.ts
@@ -107,11 +107,6 @@ export const DashboardMetricsResponseSchema = z
     return metrics;
   });
 
-export const DashboardMetricsSchema = z.partialRecord(
-  DashboardMetricKeySchema,
-  DashboardMetricApiSchema
-);
-
 const MeetingsByCompanyItemApiSchema = z.object({
   company_name: z.string().trim().min(1),
   total_meetings: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->

https://github.com/SalesPilot-AGES/Frontend/issues/68

## O que foi implementado?

Implementado o painel do vendedor com StatCards de reuniões, duração média e sentimento médio, mantendo os gráficos existentes

<img width="1910" height="905" alt="image" src="https://github.com/user-attachments/assets/147df975-ac07-4da9-967b-58923a61594b" />

<!-- Descreva o que foi feito neste PR. -->

## Por que essa mudança é necessária?

Para alinhar o dashboard do vendedor ao Figma e exibir um resumo das métricas principais do vendedor autenticado.

<!-- Explique o contexto e a motivação por trás da implementação. -->

## Como testar?

Entre como vendedor e veja se o painel do vendedor ta como na imagem que coloquei

<!-- Passos ou exemplos para validar as mudanças. -->

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
