### PR TITLE
feat: enhance ManagerDashboard with metric cards and improved layout

### DIFF
--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.test.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.test.tsx
@@ -1,6 +1,7 @@
+import { ECardLabel } from '@data/enums/ECardLabel';
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { render, screen } from '@tests/testUtils';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@tests/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@pages/DashboardPage/context/DashboardFilterContext', () => ({
   useDashboardFilterContext: () => ({
@@ -12,11 +13,115 @@ vi.mock('@pages/DashboardPage/context/DashboardFilterContext', () => ({
   }),
 }));
 
+vi.mock('@services/queries/useDashboard', () => ({
+  useGetDashboardMetrics: vi.fn(),
+  useGetMeetingsBySalesman: vi.fn(),
+  useGetMeetingsByMonth: vi.fn(),
+  useGetSalesmenStatus: vi.fn(),
+}));
+
+vi.mock('@store/hooks/useDashboardAvgDuration', () => ({
+  useDashboardAvgDuration: vi.fn(),
+}));
+
+import {
+  useGetDashboardMetrics,
+  useGetMeetingsByMonth,
+  useGetMeetingsBySalesman,
+  useGetSalesmenStatus,
+} from '@services/queries/useDashboard';
+import { useDashboardAvgDuration } from '@store/hooks/useDashboardAvgDuration';
+
 import { ManagerDashboard } from './ManagerDashboard';
 
+const mockUseGetDashboardMetrics = useGetDashboardMetrics as ReturnType<
+  typeof vi.fn
+>;
+const mockUseGetMeetingsBySalesman = useGetMeetingsBySalesman as ReturnType<
+  typeof vi.fn
+>;
+const mockUseGetMeetingsByMonth = useGetMeetingsByMonth as ReturnType<
+  typeof vi.fn
+>;
+const mockUseGetSalesmenStatus = useGetSalesmenStatus as ReturnType<
+  typeof vi.fn
+>;
+const mockUseDashboardAvgDuration = useDashboardAvgDuration as ReturnType<
+  typeof vi.fn
+>;
+
 describe('ManagerDashboard', () => {
+  beforeEach(() => {
+    mockUseGetDashboardMetrics.mockReturnValue({
+      data: {
+        active_companies: {
+          value: 0,
+          variationPercentage: 0,
+          trend: 'neutral',
+        },
+        inactive_companies: {
+          value: 0,
+          variationPercentage: 0,
+          trend: 'neutral',
+        },
+        salesmen: {
+          value: 8,
+          variationPercentage: 12,
+          trend: 'up',
+        },
+        total_meetings: {
+          value: 42,
+          variationPercentage: -5,
+          trend: 'down',
+        },
+      },
+      isError: false,
+      isLoading: false,
+    });
+    mockUseGetMeetingsBySalesman.mockReturnValue({
+      data: [],
+      isError: false,
+      isLoading: false,
+    });
+    mockUseGetMeetingsByMonth.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+    mockUseGetSalesmenStatus.mockReturnValue({
+      data: { active: 8, inactive: 2 },
+      isLoading: false,
+      isError: false,
+    });
+    mockUseDashboardAvgDuration.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
   it('renders manager dashboard title', () => {
     render(<ManagerDashboard />);
     expect(screen.getByText(EPageTitles.MANAGER_DASHBOARD)).toBeInTheDocument();
+  });
+
+  it('renders manager metric cards', () => {
+    render(<ManagerDashboard />);
+
+    expect(
+      within(
+        screen.getByTestId('manager-dashboard-metric-card-active-salesmen')
+      ).getByText(ECardLabel.ACTIVE_SALESMAN)
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByTestId('manager-dashboard-metric-card-inactive-salesmen')
+      ).getByText(ECardLabel.INACTIVE_SALESMAN)
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByTestId('manager-dashboard-metric-card-total-meetings')
+      ).getByText(ECardLabel.TOTAL_MEETINGS)
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.test.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.test.tsx
@@ -34,21 +34,11 @@ import { useDashboardAvgDuration } from '@store/hooks/useDashboardAvgDuration';
 
 import { ManagerDashboard } from './ManagerDashboard';
 
-const mockUseGetDashboardMetrics = useGetDashboardMetrics as ReturnType<
-  typeof vi.fn
->;
-const mockUseGetMeetingsBySalesman = useGetMeetingsBySalesman as ReturnType<
-  typeof vi.fn
->;
-const mockUseGetMeetingsByMonth = useGetMeetingsByMonth as ReturnType<
-  typeof vi.fn
->;
-const mockUseGetSalesmenStatus = useGetSalesmenStatus as ReturnType<
-  typeof vi.fn
->;
-const mockUseDashboardAvgDuration = useDashboardAvgDuration as ReturnType<
-  typeof vi.fn
->;
+const mockUseGetDashboardMetrics = vi.mocked(useGetDashboardMetrics);
+const mockUseGetMeetingsBySalesman = vi.mocked(useGetMeetingsBySalesman);
+const mockUseGetMeetingsByMonth = vi.mocked(useGetMeetingsByMonth);
+const mockUseGetSalesmenStatus = vi.mocked(useGetSalesmenStatus);
+const mockUseDashboardAvgDuration = vi.mocked(useDashboardAvgDuration);
 
 describe('ManagerDashboard', () => {
   beforeEach(() => {
@@ -64,11 +54,6 @@ describe('ManagerDashboard', () => {
           variationPercentage: 0,
           trend: 'neutral',
         },
-        salesmen: {
-          value: 8,
-          variationPercentage: 12,
-          trend: 'up',
-        },
         total_meetings: {
           value: 42,
           variationPercentage: -5,
@@ -77,27 +62,27 @@ describe('ManagerDashboard', () => {
       },
       isError: false,
       isLoading: false,
-    });
+    } as unknown as ReturnType<typeof useGetDashboardMetrics>);
     mockUseGetMeetingsBySalesman.mockReturnValue({
       data: [],
       isError: false,
       isLoading: false,
-    });
+    } as unknown as ReturnType<typeof useGetMeetingsBySalesman>);
     mockUseGetMeetingsByMonth.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
-    });
+    } as unknown as ReturnType<typeof useGetMeetingsByMonth>);
     mockUseGetSalesmenStatus.mockReturnValue({
       data: { active: 8, inactive: 2 },
       isLoading: false,
       isError: false,
-    });
+    } as unknown as ReturnType<typeof useGetSalesmenStatus>);
     mockUseDashboardAvgDuration.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
-    });
+    } as unknown as ReturnType<typeof useDashboardAvgDuration>);
   });
 
   it('renders manager dashboard title', () => {

--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
@@ -2,9 +2,8 @@ import { ECardLabel } from '@data/enums/ECardLabel';
 import { EMeetingsByTitle } from '@data/enums/EMeetingsByTitle';
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
-import { Box, Stack, useTheme } from '@mui/material';
+import { Box, Grid, Stack, useTheme } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
-import { InsightChip } from '@pages/DashboardPage/components/InsightChip/InsightChip';
 import { MeetingsByChart } from '@pages/DashboardPage/components/MeetingsByChart/MeetingsByChart';
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
 import { SalesmenStatusChart } from '@pages/DashboardPage/components/SalesmenStatusChart/SalesmenStatusChart';
@@ -21,7 +20,7 @@ import type { JSX } from 'react';
 import { useMemo } from 'react';
 
 export const ManagerDashboard = (): JSX.Element => {
-  const { palette, spacing } = useTheme();
+  const { palette } = useTheme();
   const { filters } = useDashboardFilterContext();
   const { data = [], isError, isLoading } = useGetMeetingsBySalesman(filters);
   const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
@@ -36,16 +35,9 @@ export const ManagerDashboard = (): JSX.Element => {
     [data]
   );
 
-  const activeSalesmenMetric = dashboardMetrics?.salesmen ?? {
-    value: salesmenStatus?.active ?? 0,
-    variationPercentage: 0,
-    trend: 'neutral' as const,
-  };
-  const totalMeetingsMetric = dashboardMetrics?.total_meetings ?? {
-    value: 0,
-    variationPercentage: 0,
-    trend: 'neutral' as const,
-  };
+  const activeSalesmenValue =
+    dashboardMetrics?.salesmen.value ?? salesmenStatus?.active ?? 0;
+  const totalMeetingsValue = dashboardMetrics?.total_meetings.value ?? 0;
 
   return (
     <PageContainter>
@@ -55,68 +47,43 @@ export const ManagerDashboard = (): JSX.Element => {
           subtitle={EpageDescriptions.MANAGER_DASHBOARD}
         />
 
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: 'repeat(2, minmax(0, 1fr))',
-              lg: 'repeat(3, minmax(0, 1fr))',
-            },
-            gap: 2,
-          }}
-        >
-          <Box
+        <Grid container spacing={2}>
+          <Grid
+            size={{ xs: 12, sm: 6, lg: 4 }}
             data-testid="manager-dashboard-metric-card-active-salesmen"
-            sx={{ position: 'relative' }}
           >
             <StatCard
               iconName="salesman"
               theme="salesmen"
-              value={activeSalesmenMetric.value}
+              value={activeSalesmenValue}
               label={ECardLabel.ACTIVE_SALESMAN}
             />
-            <InsightChip
-              variationPercentage={activeSalesmenMetric.variationPercentage}
-              trend={activeSalesmenMetric.trend}
-              sx={{
-                position: 'absolute',
-                top: spacing(3),
-                right: spacing(3),
-              }}
-            />
-          </Box>
+          </Grid>
 
-          <Box data-testid="manager-dashboard-metric-card-inactive-salesmen">
+          <Grid
+            size={{ xs: 12, sm: 6, lg: 4 }}
+            data-testid="manager-dashboard-metric-card-inactive-salesmen"
+          >
             <StatCard
               iconName="salesman"
               theme="neutrals"
               value={salesmenStatus?.inactive ?? 0}
               label={ECardLabel.INACTIVE_SALESMAN}
             />
-          </Box>
+          </Grid>
 
-          <Box
+          <Grid
+            size={{ xs: 12, sm: 6, lg: 4 }}
             data-testid="manager-dashboard-metric-card-total-meetings"
-            sx={{ position: 'relative' }}
           >
             <StatCard
               iconName="meeting"
               theme="meetings"
-              value={totalMeetingsMetric.value}
+              value={totalMeetingsValue}
               label={ECardLabel.TOTAL_MEETINGS}
             />
-            <InsightChip
-              variationPercentage={totalMeetingsMetric.variationPercentage}
-              trend={totalMeetingsMetric.trend}
-              sx={{
-                position: 'absolute',
-                top: spacing(3),
-                right: spacing(3),
-              }}
-            />
-          </Box>
-        </Box>
+          </Grid>
+        </Grid>
 
         <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
           <Box sx={{ flex: 1, minWidth: 0, height: '100%' }}>

--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
@@ -35,9 +35,8 @@ export const ManagerDashboard = (): JSX.Element => {
     [data]
   );
 
-  const activeSalesmenValue =
-    dashboardMetrics?.salesmen.value ?? salesmenStatus?.active ?? 0;
-  const totalMeetingsValue = dashboardMetrics?.total_meetings.value ?? 0;
+  const activeSalesmenValue = salesmenStatus?.active ?? 0;
+  const totalMeetingsValue = dashboardMetrics?.total_meetings?.value ?? 0;
 
   return (
     <PageContainter>

--- a/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
+++ b/src/pages/DashboardPage/ManagerDashboard/ManagerDashboard.tsx
@@ -1,22 +1,31 @@
+import { ECardLabel } from '@data/enums/ECardLabel';
 import { EMeetingsByTitle } from '@data/enums/EMeetingsByTitle';
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
 import { EPageTitles } from '@data/enums/EPageTitles';
 import { Box, Stack, useTheme } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
+import { InsightChip } from '@pages/DashboardPage/components/InsightChip/InsightChip';
 import { MeetingsByChart } from '@pages/DashboardPage/components/MeetingsByChart/MeetingsByChart';
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
 import { SalesmenStatusChart } from '@pages/DashboardPage/components/SalesmenStatusChart/SalesmenStatusChart';
 import { useDashboardFilterContext } from '@pages/DashboardPage/context/DashboardFilterContext';
-import { useGetMeetingsBySalesman } from '@services/queries/useDashboard';
+import {
+  useGetDashboardMetrics,
+  useGetMeetingsBySalesman,
+  useGetSalesmenStatus,
+} from '@services/queries/useDashboard';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
+import { StatCard } from '@UI/StatCard/StatCard';
 import type { JSX } from 'react';
 import { useMemo } from 'react';
 
 export const ManagerDashboard = (): JSX.Element => {
-  const { palette } = useTheme();
+  const { palette, spacing } = useTheme();
   const { filters } = useDashboardFilterContext();
   const { data = [], isError, isLoading } = useGetMeetingsBySalesman(filters);
+  const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
+  const { data: salesmenStatus } = useGetSalesmenStatus();
 
   const chartData = useMemo(
     () =>
@@ -27,13 +36,88 @@ export const ManagerDashboard = (): JSX.Element => {
     [data]
   );
 
+  const activeSalesmenMetric = dashboardMetrics?.salesmen ?? {
+    value: salesmenStatus?.active ?? 0,
+    variationPercentage: 0,
+    trend: 'neutral' as const,
+  };
+  const totalMeetingsMetric = dashboardMetrics?.total_meetings ?? {
+    value: 0,
+    variationPercentage: 0,
+    trend: 'neutral' as const,
+  };
+
   return (
     <PageContainter>
-      <Stack spacing={4} sx={{ width: '100%' }}>
+      <Stack spacing={2} sx={{ width: '100%' }}>
         <PageHeader
           title={EPageTitles.MANAGER_DASHBOARD}
           subtitle={EpageDescriptions.MANAGER_DASHBOARD}
         />
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, minmax(0, 1fr))',
+              lg: 'repeat(3, minmax(0, 1fr))',
+            },
+            gap: 2,
+          }}
+        >
+          <Box
+            data-testid="manager-dashboard-metric-card-active-salesmen"
+            sx={{ position: 'relative' }}
+          >
+            <StatCard
+              iconName="salesman"
+              theme="salesmen"
+              value={activeSalesmenMetric.value}
+              label={ECardLabel.ACTIVE_SALESMAN}
+            />
+            <InsightChip
+              variationPercentage={activeSalesmenMetric.variationPercentage}
+              trend={activeSalesmenMetric.trend}
+              sx={{
+                position: 'absolute',
+                top: spacing(3),
+                right: spacing(3),
+              }}
+            />
+          </Box>
+
+          <Box data-testid="manager-dashboard-metric-card-inactive-salesmen">
+            <StatCard
+              iconName="salesman"
+              theme="neutrals"
+              value={salesmenStatus?.inactive ?? 0}
+              label={ECardLabel.INACTIVE_SALESMAN}
+            />
+          </Box>
+
+          <Box
+            data-testid="manager-dashboard-metric-card-total-meetings"
+            sx={{ position: 'relative' }}
+          >
+            <StatCard
+              iconName="meeting"
+              theme="meetings"
+              value={totalMeetingsMetric.value}
+              label={ECardLabel.TOTAL_MEETINGS}
+            />
+            <InsightChip
+              variationPercentage={totalMeetingsMetric.variationPercentage}
+              trend={totalMeetingsMetric.trend}
+              sx={{
+                position: 'absolute',
+                top: spacing(3),
+                right: spacing(3),
+              }}
+            />
+          </Box>
+        </Box>
+
         <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
           <Box sx={{ flex: 1, minWidth: 0, height: '100%' }}>
             <SalesmenStatusChart />


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Frontend/issues/61

## O que foi implementado?

 - Adicionados StatCards no topo do ManagerDashboard.
  - Incluídos cards de:
      - Vendedores ativos
      - Vendedores inativos
      - Total de reuniões

  - Adicionado InsightChip nos cards com variação percentual.
  - Ajustado o grid do dashboard do gerente para 3 colunas em telas grandes, ocupando toda a largura disponível.
  - Mantidos os gráficos existentes:
      - Status dos vendedores
      - Reuniões por mês
      - Reuniões por vendedor
      - Duração média das reuniões

  - Atualizado o teste do ManagerDashboard para validar os cards adicionados.
  
  
<img width="1887" height="956" alt="image" src="https://github.com/user-attachments/assets/05b31dfd-88ad-42f7-8c3d-5151d1beff29" />


## Por que essa mudança é necessária?

O dashboard do gerente estava incompleto em relação à hierarquia visual definida no Figma e ao padrão já usado no AdminDashboard.
  A tela não exibia métricas resumidas no topo, deixando o gestor sem uma visão rápida sobre vendedores e reuniões da equipe.

  A mudança alinha o ManagerDashboard ao layout esperado: cards de métricas primeiro, depois os gráficos.

## Como testar?

 1. Rodar a aplicação frontend.
  2. Fazer login com usuário gerente.
  3. Acessar o dashboard.
  4. Verificar se a tela exibe:
      - Título Painel do Gerente
      - Subtítulo Visão geral da empresa
      - Cards de vendedores ativos, vendedores inativos e total de reuniões
      - Gráficos abaixo dos cards

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
