### PR TITLE
feat: enhance ManagerMeetingsPage and MeetingActionPlan with detailed…

### DIFF
--- a/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.test.tsx
+++ b/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.test.tsx
@@ -1,12 +1,128 @@
 import { EPageTitles } from '@data/enums/EPageTitles';
 import { render, screen } from '@tests/testUtils';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@services/queries/useMeetings', () => ({
+  useGetMeetings: vi.fn(),
+}));
+
+vi.mock('@services/queries/useSalesmen', () => ({
+  useGetSalesmen: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
+    '@tanstack/react-router'
+  );
+
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+import { useGetMeetings } from '@services/queries/useMeetings';
+import { useGetSalesmen } from '@services/queries/useSalesmen';
 
 import { ManagerMeetingsPage } from './ManagerMeetingsPage';
 
+const mockUseGetMeetings = useGetMeetings as ReturnType<typeof vi.fn>;
+const mockUseGetSalesmen = useGetSalesmen as ReturnType<typeof vi.fn>;
+
+const mockMeetings = [
+  {
+    id: 'meeting-1',
+    title: 'Reunião de descoberta',
+    sellerName: 'Ana Silva',
+    companyName: 'Acme Ltda',
+    date: '2026-05-20T10:00:00Z',
+    durationMinutes: 40,
+    status: 'COMPLETED',
+  },
+  {
+    id: 'meeting-2',
+    title: 'Demonstração comercial',
+    sellerName: 'Bruno Souza',
+    companyName: 'Beta SA',
+    date: '2026-05-21T10:00:00Z',
+    durationMinutes: 30,
+    status: 'SCHEDULED',
+  },
+];
+
 describe('ManagerMeetingsPage', () => {
+  beforeEach(() => {
+    mockUseGetMeetings.mockReturnValue({
+      data: {
+        content: mockMeetings,
+        totalElements: mockMeetings.length,
+        summary: {
+          total_meetings: 12,
+          average_duration_seconds: 2700,
+          success_rate: 0.83,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseGetSalesmen.mockReturnValue({
+      data: {
+        content: [
+          {
+            id: 'salesman-1',
+            name: 'Ana Silva',
+            email: 'ana@example.com',
+            company: { id: 'company-1', name: 'Acme Ltda' },
+            active: true,
+          },
+          {
+            id: 'salesman-2',
+            name: 'Bruno Souza',
+            email: 'bruno@example.com',
+            company: { id: 'company-2', name: 'Beta SA' },
+            active: true,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+  });
+
   it('renders meetings title', () => {
     render(<ManagerMeetingsPage />);
     expect(screen.getByText(EPageTitles.MEETINGS)).toBeInTheDocument();
+  });
+
+  it('renders manager meeting stat cards', () => {
+    render(<ManagerMeetingsPage />);
+
+    expect(screen.getByText('Total de reuniões')).toBeInTheDocument();
+    expect(screen.getByText('Duração média')).toBeInTheDocument();
+    expect(screen.getByText('Sentimento médio')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('45 min')).toBeInTheDocument();
+    expect(screen.getByText('83%')).toBeInTheDocument();
+  });
+
+  it('renders meetings table with manager columns and rows', () => {
+    render(<ManagerMeetingsPage />);
+
+    expect(screen.getByText('Lista de reuniões')).toBeInTheDocument();
+    expect(screen.getByText('Reunião')).toBeInTheDocument();
+    expect(screen.getByText('Vendedor')).toBeInTheDocument();
+    expect(screen.getByText('Empresa')).toBeInTheDocument();
+    expect(screen.getByText('Data')).toBeInTheDocument();
+    expect(screen.getByText('Duração')).toBeInTheDocument();
+    expect(screen.getByText('Reunião de descoberta')).toBeInTheDocument();
+    expect(screen.getByText('Ana Silva')).toBeInTheDocument();
+    expect(screen.getByText('Acme Ltda')).toBeInTheDocument();
+  });
+
+  it('loads salesman filter options', () => {
+    render(<ManagerMeetingsPage />);
+
+    expect(mockUseGetSalesmen).toHaveBeenCalledWith(0, 100, {});
+    expect(
+      screen.getByLabelText('Filtrar reuniões por vendedor')
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.tsx
+++ b/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.tsx
@@ -1,16 +1,209 @@
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
+import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { EPageTitles } from '@data/enums/EPageTitles';
+import type { DataTableProps } from '@declarations/ui';
+import { getSentimentConfig } from '@hooks/useSentiment';
+import ApartmentIcon from '@mui/icons-material/Apartment';
+import EventIcon from '@mui/icons-material/Event';
+import PersonIcon from '@mui/icons-material/Person';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import { Box, Stack, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import type { TMeetingListItem } from '@services/models/MeetingSchema';
+import { useGetMeetings } from '@services/queries/useMeetings';
+import { useGetSalesmen } from '@services/queries/useSalesmen';
+import { useNavigate } from '@tanstack/react-router';
+import { DataTable } from '@UI/DataTable/DataTable';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
-import type { JSX } from 'react';
+import { StatCard } from '@UI/StatCard/StatCard';
+import type { JSX, ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+
+const formatMeetingDate = (date: string): string => {
+  return new Intl.DateTimeFormat('pt-BR').format(new Date(date));
+};
+
+const formatDuration = (minutes: number): string => {
+  return `${minutes} min`;
+};
 
 export const ManagerMeetingsPage = (): JSX.Element => {
+  const { palette } = useTheme();
+  const navigate = useNavigate();
+
+  const [searchValue, setSearchValue] = useState('');
+  const [filterValue, setFilterValue] = useState('');
+
+  const filters = useMemo(
+    () => ({
+      ...(searchValue.trim() && { search: searchValue.trim() }),
+    }),
+    [searchValue]
+  );
+
+  const { data: salesmenPage } = useGetSalesmen(0, 100, {});
+  const { data, isLoading } = useGetMeetings(0, 20, filters);
+
+  const meetings = useMemo(() => data?.content ?? [], [data?.content]);
+  const summary = data?.summary;
+
+  const filteredMeetings = useMemo(() => {
+    if (!filterValue) {
+      return meetings;
+    }
+
+    return meetings.filter((meeting) => meeting.sellerName === filterValue);
+  }, [meetings, filterValue]);
+
+  const salesmanFilterOptions = useMemo(() => {
+    const salesmanNames = Array.from(
+      new Set((salesmenPage?.content ?? []).map((salesman) => salesman.name))
+    )
+      .filter((name) => name.trim().length > 0)
+      .sort((a, b) => a.localeCompare(b, 'pt-BR'));
+
+    return [
+      { label: 'Todos', value: '' },
+      ...salesmanNames.map((name) => ({ label: name, value: name })),
+    ];
+  }, [salesmenPage]);
+
+  const successRatePercent =
+    summary != null ? Math.round(summary.success_rate * 100) : undefined;
+  const sentimentConfig = getSentimentConfig(successRatePercent);
+
+  const columns: DataTableProps<TMeetingListItem>['columns'] = [
+    {
+      header: 'Reunião',
+      accessor: (row: TMeetingListItem) => row.title,
+      render: (value: ReactNode) => (
+        <Stack direction="row" alignItems="center" spacing="0.5rem">
+          <EventIcon
+            sx={{ color: palette.meetings[500], fontSize: '1.5rem' }}
+          />
+          <Typography fontWeight={500} fontSize="1rem" lineHeight="1.375rem">
+            {value ?? '-'}
+          </Typography>
+        </Stack>
+      ),
+    },
+    {
+      header: 'Vendedor',
+      accessor: (row: TMeetingListItem) => row.sellerName,
+      render: (value: ReactNode) => (
+        <Stack direction="row" alignItems="center" spacing="0.5rem">
+          <PersonIcon
+            sx={{ color: palette.salesmen[500], fontSize: '1.5rem' }}
+          />
+          <Typography fontWeight={500} fontSize="1rem" lineHeight="1.375rem">
+            {value ?? '-'}
+          </Typography>
+        </Stack>
+      ),
+    },
+    {
+      header: 'Empresa',
+      accessor: (row: TMeetingListItem) => row.companyName,
+      render: (value: ReactNode) => (
+        <Stack direction="row" alignItems="center" spacing="0.5rem">
+          <ApartmentIcon
+            sx={{ color: palette.companies[500], fontSize: '1.5rem' }}
+          />
+          <Typography fontWeight={500} fontSize="1rem" lineHeight="1.375rem">
+            {value ?? '-'}
+          </Typography>
+        </Stack>
+      ),
+    },
+    {
+      header: 'Data',
+      accessor: (row: TMeetingListItem) => row.date,
+      render: (value: ReactNode) => (
+        <Typography fontWeight={500} fontSize="1rem" lineHeight="1.375rem">
+          {typeof value === 'string' ? formatMeetingDate(value) : '-'}
+        </Typography>
+      ),
+    },
+    {
+      header: 'Duração',
+      accessor: (row: TMeetingListItem) => row.durationMinutes,
+      render: (value: ReactNode) => (
+        <Stack direction="row" alignItems="center" spacing="0.5rem">
+          <ScheduleIcon
+            sx={{ color: palette.primary[500], fontSize: '1.5rem' }}
+          />
+          <Typography fontWeight={500} fontSize="1rem" lineHeight="1.375rem">
+            {typeof value === 'number' ? formatDuration(value) : '-'}
+          </Typography>
+        </Stack>
+      ),
+    },
+  ];
+
   return (
     <PageContainter>
-      <PageHeader
-        title={EPageTitles.MEETINGS}
-        subtitle={EpageDescriptions.MEETINGS}
-      />
+      <Stack spacing="2.5rem" sx={{ height: '100%' }}>
+        <PageHeader
+          title={EPageTitles.MEETINGS}
+          subtitle={EpageDescriptions.MEETINGS}
+        />
+
+        <Box display="flex" gap="1.5rem">
+          <StatCard
+            iconName="meeting"
+            theme="meetings"
+            value={summary?.total_meetings ?? 0}
+            label="Total de reuniões"
+          />
+
+          <StatCard
+            iconName="duration"
+            theme="neutrals"
+            value={
+              summary
+                ? `${Math.round(summary.average_duration_seconds / 60)} min`
+                : '0 min'
+            }
+            label="Duração média"
+          />
+
+          <StatCard
+            iconName={sentimentConfig.iconName}
+            theme={sentimentConfig.theme}
+            value={successRatePercent != null ? `${successRatePercent}%` : '0%'}
+            label="Sentimento médio"
+          />
+        </Box>
+
+        <DataTable
+          data={filteredMeetings}
+          columns={columns}
+          getRowId={(row: TMeetingListItem) => row.id}
+          loading={isLoading}
+          sx={{
+            border: `1px solid ${palette.neutrals[200]}`,
+            flex: 1,
+            minHeight: 0,
+          }}
+          onDetailsClick={(rowId) => {
+            navigate({
+              to: EPageRoutes.SALESMAN_MEETINGS_DETAIL,
+              params: { meetingId: String(rowId) },
+            });
+          }}
+          onSearchChange={setSearchValue}
+          onFilterChange={setFilterValue}
+          searchValue={searchValue}
+          filterValue={filterValue}
+          toolbarTitle="Lista de reuniões"
+          searchPlaceholder="Buscar reunião..."
+          searchAriaLabel="Buscar reunião"
+          filterPlaceholder="Filtrar"
+          filterAriaLabel="Filtrar reuniões por vendedor"
+          filterOptions={salesmanFilterOptions}
+        />
+      </Stack>
     </PageContainter>
   );
 };

--- a/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.tsx
+++ b/src/pages/MeetingsPage/ManagerMeetingsPage/ManagerMeetingsPage.tsx
@@ -43,7 +43,11 @@ export const ManagerMeetingsPage = (): JSX.Element => {
   );
 
   const { data: salesmenPage } = useGetSalesmen(0, 100, {});
-  const { data, isLoading } = useGetMeetings(0, 20, filters);
+  // O filtro de vendedor (filterValue) é aplicado client-side abaixo porque
+  // a API só suporta filtro por título/empresa, não por vendedor. Buscamos
+  // um tamanho de página maior para reduzir a chance do filtro esconder
+  // reuniões que estão fora da primeira página.
+  const { data, isLoading } = useGetMeetings(0, 100, filters);
 
   const meetings = useMemo(() => data?.content ?? [], [data?.content]);
   const summary = data?.summary;

--- a/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/components/MeetingDetailHeaderStats.test.tsx
+++ b/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/components/MeetingDetailHeaderStats.test.tsx
@@ -1,0 +1,61 @@
+import { useTheme } from '@mui/material/styles';
+import type { TMeetingDetail } from '@services/models/MeetingSchema';
+import { render, screen } from '@tests/testUtils';
+import type { JSX } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MeetingDetailHeaderStats } from './MeetingDetailHeaderStats';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: 'a',
+}));
+
+const mockMeeting: TMeetingDetail = {
+  id: 'meeting-1',
+  title: 'Reunião de descoberta',
+  status: 'SCHEDULED',
+  meeting_type: 'ONLINE',
+  objective: 'Entender dores e objetivos',
+  client_needs: 'Melhorar eficiência',
+  previous_interactions: 'Contato inicial via email',
+  competitors_involved: 'Concorrente X',
+  scheduled_for: '2026-05-04T14:21:48.07065',
+  started_at: null,
+  ended_at: null,
+  duration_seconds: 1800,
+  seller: {
+    id: 'seller-1',
+    name: 'Saulo Souza',
+    email: 'saulo@digitalsales.com',
+  },
+  client: {
+    id: 'client-1',
+    name: 'Marina Lima',
+    client_company_name: 'Alfa Industrial',
+    sector: 'Manufacturing',
+    overall_sentiment: 8,
+  },
+};
+
+const HeaderStatsTestHarness = (): JSX.Element => {
+  const { palette } = useTheme();
+
+  return (
+    <MeetingDetailHeaderStats
+      meeting={mockMeeting}
+      sentimentScore={0.9}
+      palette={palette}
+      themePalette={palette}
+      responsiveValueFontSize="1rem"
+    />
+  );
+};
+
+describe('MeetingDetailHeaderStats', () => {
+  it('renders meeting title and status', () => {
+    render(<HeaderStatsTestHarness />);
+
+    expect(screen.getByText('Reunião de descoberta')).toBeInTheDocument();
+    expect(screen.getByText('Agendada')).toBeInTheDocument();
+  });
+});

--- a/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/components/MeetingDetailHeaderStats.test.tsx
+++ b/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/components/MeetingDetailHeaderStats.test.tsx
@@ -1,7 +1,5 @@
-import { useTheme } from '@mui/material/styles';
 import type { TMeetingDetail } from '@services/models/MeetingSchema';
 import { render, screen } from '@tests/testUtils';
-import type { JSX } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { MeetingDetailHeaderStats } from './MeetingDetailHeaderStats';
@@ -37,23 +35,11 @@ const mockMeeting: TMeetingDetail = {
   },
 };
 
-const HeaderStatsTestHarness = (): JSX.Element => {
-  const { palette } = useTheme();
-
-  return (
-    <MeetingDetailHeaderStats
-      meeting={mockMeeting}
-      sentimentScore={0.9}
-      palette={palette}
-      themePalette={palette}
-      responsiveValueFontSize="1rem"
-    />
-  );
-};
-
 describe('MeetingDetailHeaderStats', () => {
   it('renders meeting title and status', () => {
-    render(<HeaderStatsTestHarness />);
+    render(
+      <MeetingDetailHeaderStats meeting={mockMeeting} sentimentScore={0.9} />
+    );
 
     expect(screen.getByText('Reunião de descoberta')).toBeInTheDocument();
     expect(screen.getByText('Agendada')).toBeInTheDocument();

--- a/src/services/queries/useMeetings.ts
+++ b/src/services/queries/useMeetings.ts
@@ -37,7 +37,7 @@ export const useGetMeetings = (
   return useQuery<TMeetingsListResult, Error>({
     queryKey: meetingsQueryKeys.list(page, size, filters),
     queryFn: () => meetingApi.getMeetings(page, size, filters),
-    staleTime: 0,
+    staleTime: 1000 * 60 * 5,
     ...options,
   });
 };


### PR DESCRIPTION
## Issue relacionada

https://github.com/SalesPilot-AGES/Frontend/issues/63 e https://github.com/SalesPilot-AGES/Frontend/issues/64

## O que foi implementado?

- Implementada a tela de reuniões do gestor (ManagerMeetingsPage).
  - Adicionados 3 cards de métricas: total de reuniões, duração média e sentimento médio.
  - Adicionada tabela de reuniões com colunas: Reunião, Vendedor, Empresa, Data e Duração.
  - Adicionado campo de busca por nome da reunião.
  - Adicionado filtro por vendedor usando useGetSalesmen(0, 100, {}).
  - Adicionado filtro local por sellerName.
  - Adicionada navegação para detalhe da reunião via EPageRoutes.SALESMAN_MEETINGS_DETAIL.
  - Ajustada a tela de detalhe da reunião para exibir status, participantes, pré-análise, resumo, sentimento e estado de processamento do plano de ação.
  - Atualizados/adicionados testes para cobrir listagem do gestor e detalhe da reunião.
  
  
<img width="1836" height="947" alt="image" src="https://github.com/user-attachments/assets/ed9e2f04-af0a-4f83-a48a-7ce6fa83a13f" />
<img width="1852" height="982" alt="image" src="https://github.com/user-attachments/assets/5cf4b389-235f-4d7d-b333-68f4457b8e33" />


## Por que essa mudança é necessária?

 A tela de reuniões do gestor estava apenas como stub, sem métricas, tabela, filtros ou integração com o detalhe da reunião.

  A mudança permite que o gestor visualize e filtre reuniões da sua equipe, acesse os detalhes de cada reunião e consulte contexto, insights e plano de ação
  com a mesma experiência já esperada no fluxo de reuniões.

## Como testar?

 1. Fazer login com usuário gestor.
  2. Acessar a página de reuniões.
  3. Verificar se são exibidos:
      - Cards de total de reuniões, duração média e sentimento médio.
      - Tabela com reuniões da equipe.
      - Busca por reunião.
      - Filtro por vendedor.

  4. Clicar em detalhes de uma reunião.
  5. Verificar se a tela de detalhe exibe:
      - Título, status e cards do cabeçalho.
      - Aba Contexto com participantes e pré-análise.
      - Aba Insights com loading/vazio/listagem.
      - Aba Plano de Ação com resumo, sentimento, ações ou estado de processamento.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [x] Testes foram adicionados ou atualizados para cobrir as mudanças
