### PR TITLE
feat: add manager salesman detail access (#65)

### DIFF
--- a/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
+++ b/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
@@ -1,5 +1,6 @@
 import { ECardLabel } from '@data/enums/ECardLabel';
 import { EpageDescriptions } from '@data/enums/EpageDescriptions';
+import { EPageRoutes } from '@data/enums/EPageRoutes';
 import { EPageTitles } from '@data/enums/EPageTitles';
 import { EStatus } from '@data/enums/EStatus';
 import { getSentimentConfig } from '@hooks/useSentiment';
@@ -8,6 +9,7 @@ import { Box, Button, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import type { TSalesmanWithCompany } from '@services/models/SalesmanSchema';
 import { useGetSalesmen } from '@services/queries/useSalesmen';
+import { useNavigate } from '@tanstack/react-router';
 import { DataTable } from '@UI/DataTable/DataTable';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
@@ -21,6 +23,7 @@ import { buildManagerSalesmenColumns } from './salesmenColumns';
 
 export const ManagerSalesmenPage = (): JSX.Element => {
   const { palette } = useTheme();
+  const navigate = useNavigate({ from: EPageRoutes.SALESMEN });
   const [searchValue, setSearchValue] = useState('');
   const [filterValue, setFilterValue] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -122,7 +125,12 @@ export const ManagerSalesmenPage = (): JSX.Element => {
             flex: 1,
             minHeight: 0,
           }}
-          onDetailsClick={() => {}}
+          onDetailsClick={(id) =>
+            navigate({
+              to: EPageRoutes.SALESMAN_DETAIL,
+              params: { id: String(id) },
+            })
+          }
           onSearchChange={setSearchValue}
           onFilterChange={setFilterValue}
           searchValue={searchValue}

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -50,7 +50,8 @@ export const SalesmanDetail = (): JSX.Element => {
   } = useAdminSalesmenDetailsEdit(
     salesman ?? null,
     isEditing,
-    handleCancelEdit
+    handleCancelEdit,
+    canEdit
   );
 
   if (isLoading) {

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -13,6 +13,7 @@ import {
 import { PageNotFound } from '@pages/PageNotFound/PageNotFound';
 import { useGetSalesmanById } from '@services/queries/useSalesmen';
 import { useAdminSalesmenDetailsEdit } from '@store/hooks/useAdminSalesmenDetailsEdit';
+import { useCurrentUserRole } from '@store/hooks/useCurrentUser';
 import { Link, useParams } from '@tanstack/react-router';
 import { EntityDetailsCard } from '@UI/EntityDetailsCard/EntityDetailsCard';
 import { IconBox } from '@UI/IconBox/IconBox';
@@ -27,6 +28,8 @@ export const SalesmanDetail = (): JSX.Element => {
   const { palette } = useTheme();
   const { id } = useParams({ strict: false }) as { id: string };
   const { data: salesman, isLoading, isError } = useGetSalesmanById(id ?? null);
+  const role = useCurrentUserRole();
+  const canEdit = role === 'admin';
   const [isEditing, setIsEditing] = useState(false);
 
   const handleStartEdit = (): void => {
@@ -97,7 +100,7 @@ export const SalesmanDetail = (): JSX.Element => {
 
         <EntityDetailsCard
           title={EPageTitles.SALESMAN_INFORMATION}
-          onEdit={isEditing ? undefined : handleStartEdit}
+          onEdit={isEditing || !canEdit ? undefined : handleStartEdit}
           headerRight={
             isEditing ? (
               <Box

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
@@ -43,12 +43,10 @@ export const SalesmanInformationView = ({
       icon={<EmailIcon fontSize="small" />}
     />
 
-    {salesman.phone && (
-      <ItemDetail
-        label="Telefone"
-        value={salesman.phone}
-        icon={<PhoneIcon fontSize="small" />}
-      />
-    )}
+    <ItemDetail
+      label="Telefone"
+      value={salesman.phone || 'Não informado'}
+      icon={<PhoneIcon fontSize="small" />}
+    />
   </Box>
 );

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationView/SalesmanInformationView.tsx
@@ -1,5 +1,6 @@
 import BusinessIcon from '@mui/icons-material/Business';
 import EmailIcon from '@mui/icons-material/Email';
+import PhoneIcon from '@mui/icons-material/Phone';
 import { Box } from '@mui/material';
 import type { TSalesman } from '@services/models/SalesmanSchema';
 import { ItemDetail } from '@UI/ItemDetail/ItemDetail';
@@ -41,5 +42,13 @@ export const SalesmanInformationView = ({
       value={salesman.email}
       icon={<EmailIcon fontSize="small" />}
     />
+
+    {salesman.phone && (
+      <ItemDetail
+        label="Telefone"
+        value={salesman.phone}
+        icon={<PhoneIcon fontSize="small" />}
+      />
+    )}
   </Box>
 );

--- a/src/store/hooks/useAdminSalesmenDetailsEdit.ts
+++ b/src/store/hooks/useAdminSalesmenDetailsEdit.ts
@@ -25,7 +25,8 @@ const createEditForm = (salesman: TSalesman): TSalesmanEditForm => ({
 export const useAdminSalesmenDetailsEdit = (
   salesman: TSalesman | null,
   isEditing: boolean,
-  onSaveSuccess?: () => void
+  onSaveSuccess?: () => void,
+  canEdit: boolean = true
 ): {
   editForm: TSalesmanEditForm | null;
   isEditFormValid: boolean;
@@ -37,7 +38,9 @@ export const useAdminSalesmenDetailsEdit = (
   ) => void;
   handleStatusChange: (checked: boolean) => void;
 } => {
-  const { data: companiesResponse } = useGetCompanies(0, 200);
+  const { data: companiesResponse } = useGetCompanies(0, 200, undefined, {
+    enabled: canEdit,
+  } as Parameters<typeof useGetCompanies>[3]);
   const updateSalesmanMutation = useUpdateSalesman();
   const [draftEditForm, setDraftEditForm] = useState<TSalesmanEditForm | null>(
     null


### PR DESCRIPTION
## Issue relacionada
Closes #65

[<!-- Link da issue no GitHub. -->](https://github.com/SalesPilot-AGES/Frontend/issues/65)

## O que foi implementado?

- Adicionado `onDetailsClick` no `ManagerSalesmenPage` para navegar 
  para a tela de detalhe do vendedor com o `id` do vendedor
- Restringido o botão de editar para role `admin` no `SalesmanDetail` 
  (gestor vê a tela somente leitura)
- Exibido campo de telefone no `SalesmanInformationView` 
  quando disponível no contrato

## Por que essa mudança é necessária?

O GESTOR precisava de acesso à tela de detalhe dos vendedores da 
sua equipe, funcionalidade que até então só existia para o ADMIN. 
A implementação reutiliza a tela existente com controle de permissão 
por role, sem regressão no fluxo do ADMIN.

## Como testar?

1. Logar como GESTOR
2. Acessar a listagem de vendedores
3. Clicar no botão de detalhes (→) de qualquer vendedor
4. Verificar que a tela abre corretamente e o botão Editar não aparece
5. Logar como ADMIN e repetir — o botão Editar deve aparecer normalmente

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças

⚠️ Os 22 testes falhando (authStore, useCurrentUser, useLoginForm, 
useUserProfile) são falhas pré-existentes na development, não 
introduzidas por esta branch.