### PR TITLE
fix(meetings): corrige filtro de empresa no admin de reuniões

### DIFF
--- a/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
+++ b/src/pages/MeetingsPage/AdminMeetingsPage/AdminMeetingsPage.tsx
@@ -9,7 +9,6 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import { Box, Stack, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import type { TMeetingListItem } from '@services/models/MeetingSchema';
-import { useGetCompanies } from '@services/queries/useCompanies';
 import { useGetMeetings } from '@services/queries/useMeetings';
 import { useNavigate } from '@tanstack/react-router';
 import { DataTable } from '@UI/DataTable/DataTable';
@@ -42,23 +41,14 @@ export const AdminMeetingsPage = (): JSX.Element => {
     [searchValue, filterValue]
   );
 
-  const { data: companiesPage } = useGetCompanies(0, 100);
   const { data, isLoading } = useGetMeetings(0, 20, filters);
 
   const meetings = useMemo(() => data?.content ?? [], [data?.content]);
   const summary = data?.summary;
 
-  const filteredMeetings = useMemo(() => {
-    if (!filterValue) {
-      return meetings;
-    }
-
-    return meetings.filter((meeting) => meeting.companyName === filterValue);
-  }, [meetings, filterValue]);
-
   const companyFilterOptions = useMemo(() => {
     const companyNames = Array.from(
-      new Set((companiesPage?.content ?? []).map((company) => company.name))
+      new Set(meetings.map((meeting) => meeting.companyName))
     )
       .filter((name) => name.trim().length > 0)
       .sort((a, b) => a.localeCompare(b, 'pt-BR'));
@@ -67,7 +57,7 @@ export const AdminMeetingsPage = (): JSX.Element => {
       { label: 'Todas', value: '' },
       ...companyNames.map((name) => ({ label: name, value: name })),
     ];
-  }, [companiesPage]);
+  }, [meetings]);
 
   const successRatePercent =
     summary != null ? Math.round(summary.success_rate * 100) : undefined;
@@ -177,7 +167,7 @@ export const AdminMeetingsPage = (): JSX.Element => {
         </Box>
 
         <DataTable
-          data={filteredMeetings}
+          data={meetings}
           columns={columns}
           getRowId={(row: TMeetingListItem) => row.id}
           loading={isLoading}

--- a/src/services/api/meeting.ts
+++ b/src/services/api/meeting.ts
@@ -33,8 +33,8 @@ export const meetingApi = {
       params: {
         page,
         size,
-        ...(filters?.search && { search: filters.search }),
-        ...(filters?.companies && { companies: filters.companies }),
+        ...(filters?.search && { title: filters.search }),
+        ...(filters?.companies && { clientCompanyName: filters.companies }),
       },
     });
 


### PR DESCRIPTION
## Issue relacionada

<!-- Link da issue no GitHub. -->

## O que foi implementado?

Correção do filtro "Empresa" na página de reuniões do admin (`AdminMeetingsPage`):

- **`meeting.ts`**: corrigidos os nomes dos parâmetros enviados ao backend — `search` → `title` e `companies` → `clientCompanyName`. Antes o backend ignorava ambos, então nem a busca por texto nem o filtro funcionavam server-side.
- **`AdminMeetingsPage.tsx`**: o dropdown de empresa agora é populado a partir dos próprios `meetings` (campo `companyName`, que é o `client_company_name` exibido na coluna EMPRESA), em vez da rota `/api/companies`.
- Removida a filtragem client-side redundante (`filteredMeetings`), delegando a filtragem ao backend.

## Por que essa mudança é necessária?

O filtro "Empresa" não funcionava por dois motivos:

1. **Mismatch de dados**: a coluna EMPRESA mostra o `client_company_name` (empresa do cliente, ex: "Banco Meridian"), mas o dropdown puxava de `/api/companies`, que retorna as empresas do sistema (ex: "Vertex Tecnologia"). Como eram dados diferentes, nenhum valor do filtro batia com o que aparecia na tabela.
2. **Nomes de params errados**: o front enviava `search`/`companies`, mas o backend espera `title`/`clientCompanyName`, então os dois params eram ignorados.

## Como testar?

1. Acessar a página de reuniões do admin.
2. Verificar que as opções do dropdown "Empresa" correspondem às empresas exibidas na coluna EMPRESA.
3. Selecionar uma empresa no filtro e confirmar que a tabela passa a exibir apenas as reuniões daquela empresa.
4. Digitar no campo de busca e confirmar que a filtragem por título funciona.

## Checklist

- [x] O código foi revisado pelo próprio autor antes de abrir o MR
- [x] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças
