### PR TITLE
Style/no ref/graph render corrections

### DIFF
--- a/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
+++ b/src/pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart.tsx
@@ -14,6 +14,7 @@ import type { JSX } from 'react';
 import { useMemo } from 'react';
 
 import { useDashboardFilterContext } from '../../context/DashboardFilterContext';
+import { CHART_TOOLTIP_SLOT_PROPS } from '../chartTooltipSlotProps';
 import { StyledLineChart } from './AvgDurationLineChart.style';
 import { formatDuration, formatMonthLabel } from './AvgDurationLineChart.utils';
 import {
@@ -126,15 +127,7 @@ export const AvgDurationLineChart = (): JSX.Element => {
             height={240}
             margin={{ top: 24, right: 24, bottom: 24, left: 50 }}
             grid={{ horizontal: true }}
-            slotProps={{
-              tooltip: {
-                sx: {
-                  '& .MuiChartsTooltip-table caption': {
-                    textAlign: 'right',
-                  },
-                },
-              },
-            }}
+            slotProps={CHART_TOOLTIP_SLOT_PROPS}
             xAxis={[
               {
                 id: 'months',

--- a/src/pages/DashboardPage/components/CompaniesStatusChart/CompaniesStatusChart.tsx
+++ b/src/pages/DashboardPage/components/CompaniesStatusChart/CompaniesStatusChart.tsx
@@ -76,13 +76,11 @@ export const CompaniesStatusChart = (): JSX.Element => {
                       {
                         id: 0,
                         value: data?.active ?? 0,
-                        label: LABEL_ACTIVE,
                         color: activeColor,
                       },
                       {
                         id: 1,
                         value: data?.inactive ?? 0,
-                        label: LABEL_INACTIVE,
                         color: inactiveColor,
                       },
                     ],
@@ -91,7 +89,9 @@ export const CompaniesStatusChart = (): JSX.Element => {
                     valueFormatter: (item): string => {
                       const percentage =
                         total > 0 ? Math.round((item.value / total) * 100) : 0;
-                      return `${item.value} (${percentage}%)`;
+                      const label =
+                        item.id === 0 ? LABEL_ACTIVE : LABEL_INACTIVE;
+                      return `${label}: ${item.value} (${percentage}%)`;
                     },
                   },
                 ]}

--- a/src/pages/DashboardPage/components/CompaniesStatusChart/CompaniesStatusChart.tsx
+++ b/src/pages/DashboardPage/components/CompaniesStatusChart/CompaniesStatusChart.tsx
@@ -76,13 +76,13 @@ export const CompaniesStatusChart = (): JSX.Element => {
                       {
                         id: 0,
                         value: data?.active ?? 0,
-                        label: `${LABEL_ACTIVE}: ${data?.active ?? 0}`,
+                        label: LABEL_ACTIVE,
                         color: activeColor,
                       },
                       {
                         id: 1,
                         value: data?.inactive ?? 0,
-                        label: `${LABEL_INACTIVE}: ${data?.inactive ?? 0}`,
+                        label: LABEL_INACTIVE,
                         color: inactiveColor,
                       },
                     ],

--- a/src/pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart.tsx
+++ b/src/pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart.tsx
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 
 import { useDashboardFilterContext } from '../../context/DashboardFilterContext';
 import { formatMonthLabel } from '../AvgDurationLineChart/AvgDurationLineChart.utils';
+import { CHART_TOOLTIP_SLOT_PROPS } from '../chartTooltipSlotProps';
 
 const EMPTY_STATE_TITLE = 'Nenhuma reunião encontrada';
 const EMPTY_STATE_DESCRIPTION =
@@ -108,15 +109,7 @@ export const MeetingsByMonthChart = (): JSX.Element => {
                 valueFormatter: (value): string => `${value ?? 0} reuniões`,
               },
             ]}
-            slotProps={{
-              tooltip: {
-                sx: {
-                  '& .MuiChartsTooltip-table caption': {
-                    textAlign: 'right',
-                  },
-                },
-              },
-            }}
+            slotProps={CHART_TOOLTIP_SLOT_PROPS}
             slots={{ legend: () => null }}
           />
         )}

--- a/src/pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart.tsx
+++ b/src/pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart.tsx
@@ -53,7 +53,16 @@ export const MeetingsByMonthChart = (): JSX.Element => {
         Total de reuniões
       </Typography>
 
-      <Box sx={{ width: '100%', height: '15rem', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          width: '100%',
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
+      >
         {isLoading ? (
           <Box
             sx={{

--- a/src/pages/DashboardPage/components/SalesmenStatusChart/SalesmenStatusChart.tsx
+++ b/src/pages/DashboardPage/components/SalesmenStatusChart/SalesmenStatusChart.tsx
@@ -76,13 +76,11 @@ export const SalesmenStatusChart = (): JSX.Element => {
                       {
                         id: 0,
                         value: data?.active ?? 0,
-                        label: `${LABEL_ACTIVE}: ${data?.active ?? 0}`,
                         color: activeColor,
                       },
                       {
                         id: 1,
                         value: data?.inactive ?? 0,
-                        label: `${LABEL_INACTIVE}: ${data?.inactive ?? 0}`,
                         color: inactiveColor,
                       },
                     ],
@@ -91,7 +89,9 @@ export const SalesmenStatusChart = (): JSX.Element => {
                     valueFormatter: (item): string => {
                       const percentage =
                         total > 0 ? Math.round((item.value / total) * 100) : 0;
-                      return `${item.value} (${percentage}%)`;
+                      const label =
+                        item.id === 0 ? LABEL_ACTIVE : LABEL_INACTIVE;
+                      return `${label}: ${item.value} (${percentage}%)`;
                     },
                   },
                 ]}

--- a/src/pages/DashboardPage/components/chartTooltipSlotProps.ts
+++ b/src/pages/DashboardPage/components/chartTooltipSlotProps.ts
@@ -1,0 +1,9 @@
+export const CHART_TOOLTIP_SLOT_PROPS = {
+  tooltip: {
+    sx: {
+      '& .MuiChartsTooltip-table caption': {
+        textAlign: 'right',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Issue relacionada

#77 

## O que foi implementado?

* Padronização do comportamento dos tooltips dos gráficos do dashboard.
* Correção dos tooltips dos gráficos de status (donut), alinhando seu comportamento ao padrão visual utilizado nos demais gráficos.
* Refatoração da configuração compartilhada de tooltip para os gráficos que utilizam tooltip de eixo.
* Ajuste do conteúdo exibido nos tooltips dos gráficos de donut utilizando valueFormatter, eliminando inconsistências visuais.
* Correção do alinhamento vertical do gráfico de reuniões por mês (MeetingsByMonthChart) no dashboard do gestor.
* Centralização do gráfico dentro do card quando há diferença de altura entre os componentes da mesma linha, mantendo os cards com alturas consistentes.

## Por que essa mudança é necessária?

Foram identificadas inconsistências visuais nos gráficos do dashboard:

* Os gráficos de donut utilizavam uma estrutura de tooltip diferente dos gráficos de linha e barra, causando divergências na apresentação das informações.
* O gráfico de reuniões por mês ficava visualmente desalinhado no dashboard do gestor devido à diferença de altura entre os cards da mesma linha, gerando espaço vazio apenas na parte inferior do componente.

As correções garantem maior consistência visual, melhor alinhamento dos elementos e uma experiência mais uniforme entre os diferentes gráficos do sistema.

## Como testar?

1. Acesse o dashboard como ADMIN.
2. Passe o mouse sobre os gráficos de status e valide o comportamento dos tooltips.
3. Verifique que os tooltips dos gráficos continuam exibindo as informações corretamente.
4. Acesse o dashboard como GESTOR.
5. Verifique o comportamento dos tooltips dos gráficos de status.
6. Verifique que o gráfico de reuniões por mês permanece centralizado dentro do card.
7. Confirme que os cards da mesma linha continuam com alturas consistentes.
8. Valide que não houve regressão visual nos demais gráficos do dashboard.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [ ] Testes foram adicionados ou atualizados para cobrir as mudanças
