### PR TITLE
refactor: updated stat card design

### DIFF
--- a/src/UI/StatCard/StatCard.test.tsx
+++ b/src/UI/StatCard/StatCard.test.tsx
@@ -52,8 +52,7 @@ describe('StatCard Component', () => {
 
   it('merges custom sx on root box', () => {
     render(<StatCard {...defaultProps} sx={{ maxWidth: '18rem' }} />);
-    const stack = screen.getByText('4').closest('[class*="MuiStack"]');
-    const root = stack?.parentElement as HTMLElement;
+    const root = screen.getByText('4').closest('[class*="MuiBox"]');
     expect(root).toHaveStyle({ maxWidth: '18rem' });
   });
 

--- a/src/UI/StatCard/StatCard.tsx
+++ b/src/UI/StatCard/StatCard.tsx
@@ -27,9 +27,7 @@ export const StatCard = ({
 
   return (
     <Box
-      gap="0.75rem"
       width="100%"
-      height="fit-content"
       sx={{
         padding: '1.5rem',
         border: '1px solid',
@@ -39,17 +37,19 @@ export const StatCard = ({
         ...sx,
       }}
     >
-      <Stack gap="0.75rem" alignItems="left">
-        <IconBox iconName={iconName} theme={theme} />
+      <Stack gap="0.75rem">
+        <Stack direction="row" alignItems="center" gap="1rem">
+          <IconBox iconName={iconName} theme={theme} />
 
-        <Typography
-          fontSize="1.5rem"
-          fontWeight="600"
-          lineHeight="2rem"
-          color={valueColor ?? palette.neutrals[900]}
-        >
-          {value}
-        </Typography>
+          <Typography
+            fontSize="2rem"
+            fontWeight="600"
+            lineHeight="2.5rem"
+            color={valueColor ?? palette.neutrals[900]}
+          >
+            {value}
+          </Typography>
+        </Stack>
 
         <Typography
           fontSize="1rem"

--- a/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/DashboardPage/AdminDashboard/AdminDashboard.tsx
@@ -5,7 +5,6 @@ import { EPageTitles } from '@data/enums/EPageTitles';
 import { Box, Stack, useTheme } from '@mui/material';
 import { AvgDurationLineChart } from '@pages/DashboardPage/components/AvgDurationLineChart/AvgDurationLineChart';
 import { CompaniesStatusChart } from '@pages/DashboardPage/components/CompaniesStatusChart/CompaniesStatusChart';
-import { InsightChip } from '@pages/DashboardPage/components/InsightChip/InsightChip';
 import { MeetingsByChart } from '@pages/DashboardPage/components/MeetingsByChart/MeetingsByChart';
 import { MeetingsByMonthChart } from '@pages/DashboardPage/components/MeetingsByMonthChart/MeetingsByMonthChart';
 import { useDashboardFilterContext } from '@pages/DashboardPage/context/DashboardFilterContext';
@@ -68,7 +67,7 @@ const getMetricValue = (
   };
 
 export const AdminDashboard = (): JSX.Element => {
-  const { palette, spacing } = useTheme();
+  const { palette } = useTheme();
   const { filters } = useDashboardFilterContext();
   const { data = [], isError, isLoading } = useGetMeetingsByCompany(filters);
   const { data: dashboardMetrics } = useGetDashboardMetrics(filters);
@@ -108,22 +107,12 @@ export const AdminDashboard = (): JSX.Element => {
               <Box
                 key={config.key}
                 data-testid={`dashboard-metric-card-${config.key}`}
-                sx={{ position: 'relative' }}
               >
                 <StatCard
                   iconName={config.iconName}
                   theme={config.iconTheme}
                   value={metric.value}
                   label={config.label}
-                />
-                <InsightChip
-                  variationPercentage={metric.variationPercentage}
-                  trend={metric.trend}
-                  sx={{
-                    position: 'absolute',
-                    top: spacing(3),
-                    right: spacing(3),
-                  }}
                 />
               </Box>
             );


### PR DESCRIPTION
## Issue relacionada

#89 

## O que foi implementado?

* Redesign visual do componente StatCard.
* Reorganização do layout para exibir o ícone e o valor principal na mesma linha.
* Aumento do tamanho do valor principal de 24px para 32px.
* Manutenção do label abaixo da área principal do card.
* Remoção visual dos InsightChips dos cards de métricas do dashboard.
* Simplificação do layout dos cards no AdminDashboard.
* Atualização do teste do StatCard para refletir a nova estrutura do componente.

## Por que essa mudança é necessária?

A mudança foi realizada a partir de um feedback do cliente sobre a visualização dos indicadores principais.

O novo layout dá mais destaque ao valor da métrica, melhora a leitura rápida dos dados e remove temporariamente os indicadores de variação, já que o sistema ainda não possui comparação temporal consolidada para essas métricas.

## Como testar?

1. Acesse o dashboard.
2. Verifique se os StatCards exibem o ícone e o valor principal na mesma linha.
3. Confirme que o valor aparece maior e com mais destaque.
4. Verifique se o label continua aparecendo abaixo do ícone/valor.
5. Confirme que os InsightChips não aparecem mais nos cards.
6. Valide que o layout permanece responsivo e alinhado.
7. Execute os testes automatizados.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [X] Testes foram adicionados ou atualizados para cobrir as mudanças
