### PR TITLE
Feat/67/manager edit salesman

### DIFF
--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent,render, screen } from '@tests/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+  useParams: vi.fn(() => ({ id: 'salesman-1' })),
+}));
+
+vi.mock('@pages/PageNotFound/PageNotFound', () => ({
+  PageNotFound: () => <div data-testid="page-not-found" />,
+}));
+
+vi.mock('@services/queries/useSalesmen', () => ({
+  useGetSalesmanById: vi.fn(),
+}));
+
+vi.mock('@store/hooks/useAdminSalesmenDetailsEdit', () => ({
+  useAdminSalesmenDetailsEdit: vi.fn(),
+}));
+
+vi.mock('@store/hooks/useCurrentUser', () => ({
+  useCurrentUserRole: vi.fn(),
+}));
+
+import { useGetSalesmanById } from '@services/queries/useSalesmen';
+import { useAdminSalesmenDetailsEdit } from '@store/hooks/useAdminSalesmenDetailsEdit';
+import { useCurrentUserRole } from '@store/hooks/useCurrentUser';
+import type React from 'react';
+
+import { SalesmanDetail } from './SalesmanDetail';
+
+const mockGetSalesmanById = useGetSalesmanById as ReturnType<typeof vi.fn>;
+const mockEditHook = useAdminSalesmenDetailsEdit as ReturnType<typeof vi.fn>;
+const mockRole = useCurrentUserRole as ReturnType<typeof vi.fn>;
+
+const mockSalesman = {
+  id: 'salesman-1',
+  name: 'João Silva',
+  email: 'joao@empresa.com',
+  company: { id: 'company-1', name: 'Empresa X' },
+  active: true,
+};
+
+const mockEditForm = {
+  name: 'João Silva',
+  email: 'joao@empresa.com',
+  companyId: 'company-1',
+  active: true,
+};
+
+const defaultHookReturn = {
+  editForm: mockEditForm,
+  isEditFormValid: true,
+  companyOptions: [{ id: 'company-1', name: 'Empresa X' }],
+  handleSaveEdit: vi.fn(),
+  handleFieldChange: vi.fn(),
+  handleStatusChange: vi.fn(),
+};
+
+describe('SalesmanDetail', () => {
+  beforeEach(() => {
+    mockEditHook.mockReturnValue(defaultHookReturn);
+  });
+
+  it('shows loading state while fetching', () => {
+    mockRole.mockReturnValue('admin');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+    });
+    render(<SalesmanDetail />);
+    expect(
+      screen.getByText('Carregando informações do vendedor...')
+    ).toBeInTheDocument();
+  });
+
+  it('shows PageNotFound on API error', () => {
+    mockRole.mockReturnValue('admin');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+    });
+    render(<SalesmanDetail />);
+    expect(screen.getByTestId('page-not-found')).toBeInTheDocument();
+  });
+
+  it('shows PageNotFound when salesman is undefined', () => {
+    mockRole.mockReturnValue('admin');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: undefined,
+    });
+    render(<SalesmanDetail />);
+    expect(screen.getByTestId('page-not-found')).toBeInTheDocument();
+  });
+
+  it('shows edit button for admin', () => {
+    mockRole.mockReturnValue('admin');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    expect(screen.getByRole('button', { name: /editar/i })).toBeInTheDocument();
+  });
+
+  it('shows edit button for manager', () => {
+    mockRole.mockReturnValue('manager');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    expect(screen.getByRole('button', { name: /editar/i })).toBeInTheDocument();
+  });
+
+  it('enters edit mode when edit button is clicked', () => {
+    mockRole.mockReturnValue('manager');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    fireEvent.click(screen.getByRole('button', { name: /editar/i }));
+    expect(
+      screen.getByRole('button', { name: /cancelar/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /salvar/i })).toBeInTheDocument();
+  });
+
+  it('returns to view mode when cancel is clicked', () => {
+    mockRole.mockReturnValue('manager');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    fireEvent.click(screen.getByRole('button', { name: /editar/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+    expect(
+      screen.queryByRole('button', { name: /cancelar/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /salvar/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes isAdmin=false to hook for manager (no company fetch)', () => {
+    mockRole.mockReturnValue('manager');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    expect(mockEditHook).toHaveBeenCalledWith(
+      mockSalesman,
+      false,
+      expect.any(Function),
+      false
+    );
+  });
+
+  it('passes isAdmin=true to hook for admin (company fetch enabled)', () => {
+    mockRole.mockReturnValue('admin');
+    mockGetSalesmanById.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: mockSalesman,
+    });
+    render(<SalesmanDetail />);
+    expect(mockEditHook).toHaveBeenCalledWith(
+      mockSalesman,
+      false,
+      expect.any(Function),
+      true
+    );
+  });
+});

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent,render, screen } from '@tests/testUtils';
+import { fireEvent, render, screen } from '@tests/testUtils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tanstack/react-router', () => ({

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanDetail.tsx
@@ -29,7 +29,8 @@ export const SalesmanDetail = (): JSX.Element => {
   const { id } = useParams({ strict: false }) as { id: string };
   const { data: salesman, isLoading, isError } = useGetSalesmanById(id ?? null);
   const role = useCurrentUserRole();
-  const canEdit = role === 'admin';
+  const canEdit = role === 'admin' || role === 'manager';
+  const isAdmin = role === 'admin';
   const [isEditing, setIsEditing] = useState(false);
 
   const handleStartEdit = (): void => {
@@ -51,7 +52,7 @@ export const SalesmanDetail = (): JSX.Element => {
     salesman ?? null,
     isEditing,
     handleCancelEdit,
-    canEdit
+    isAdmin
   );
 
   if (isLoading) {
@@ -131,6 +132,7 @@ export const SalesmanDetail = (): JSX.Element => {
               salesmanId={salesman.id}
               editForm={editForm}
               companyOptions={companyOptions}
+              isCompanyEditable={isAdmin}
               onFieldChange={handleFieldChange}
               onStatusChange={handleStatusChange}
             />

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@tests/testUtils';
+import { fireEvent, render, screen } from '@tests/testUtils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SalesmanInformationEdit } from './SalesmanInformationEdit';
@@ -90,11 +90,8 @@ describe('SalesmanInformationEdit', () => {
       />
     );
     const nameInput = screen.getByDisplayValue('João Silva');
-    nameInput.focus();
-    screen
-      .getByDisplayValue('João Silva')
-      .dispatchEvent(new Event('change', { bubbles: true }));
-    // Interaction is tested via RTL fireEvent in integration — here we verify the handler is wired
-    expect(nameInput).toBeInTheDocument();
+    fireEvent.change(nameInput, { target: { value: 'Maria Souza' } });
+
+    expect(onFieldChange).toHaveBeenCalledWith('name', 'Maria Souza');
   });
 });

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@tests/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SalesmanInformationEdit } from './SalesmanInformationEdit';
+
+const mockEditForm = {
+  name: 'João Silva',
+  email: 'joao@empresa.com',
+  companyId: 'company-1',
+  active: true,
+};
+
+const mockCompanyOptions = [{ id: 'company-1', name: 'Empresa X' }];
+
+const defaultProps = {
+  salesmanId: 'salesman-1',
+  editForm: mockEditForm,
+  companyOptions: mockCompanyOptions,
+  onFieldChange: vi.fn(),
+  onStatusChange: vi.fn(),
+};
+
+describe('SalesmanInformationEdit', () => {
+  it('pre-fills name field', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.getByDisplayValue('João Silva')).toBeInTheDocument();
+  });
+
+  it('pre-fills email field', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.getByDisplayValue('joao@empresa.com')).toBeInTheDocument();
+  });
+
+  it('shows salesman ID as read-only', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.getByText('salesman-1')).toBeInTheDocument();
+  });
+
+  it('shows active status', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.getByText('Ativo')).toBeInTheDocument();
+  });
+
+  it('shows inactive status when active=false', () => {
+    render(
+      <SalesmanInformationEdit
+        {...defaultProps}
+        editForm={{ ...mockEditForm, active: false }}
+      />
+    );
+    expect(screen.getByText('Inativo')).toBeInTheDocument();
+  });
+
+  it('does not show role field', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.queryByText(/papel|role/i)).not.toBeInTheDocument();
+  });
+
+  it('enables company select by default (admin)', () => {
+    const { container } = render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(
+      container.querySelector('.MuiInputBase-root.Mui-disabled')
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables company select for manager (isCompanyEditable=false)', () => {
+    const { container } = render(
+      <SalesmanInformationEdit {...defaultProps} isCompanyEditable={false} />
+    );
+    expect(
+      container.querySelector('.MuiInputBase-root.Mui-disabled')
+    ).toBeInTheDocument();
+  });
+
+  it('enables company select when isCompanyEditable=true', () => {
+    const { container } = render(
+      <SalesmanInformationEdit {...defaultProps} isCompanyEditable={true} />
+    );
+    expect(
+      container.querySelector('.MuiInputBase-root.Mui-disabled')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onFieldChange when name is edited', () => {
+    const onFieldChange = vi.fn();
+    render(
+      <SalesmanInformationEdit
+        {...defaultProps}
+        onFieldChange={onFieldChange}
+      />
+    );
+    const nameInput = screen.getByDisplayValue('João Silva');
+    nameInput.focus();
+    screen
+      .getByDisplayValue('João Silva')
+      .dispatchEvent(new Event('change', { bubbles: true }));
+    // Interaction is tested via RTL fireEvent in integration — here we verify the handler is wired
+    expect(nameInput).toBeInTheDocument();
+  });
+});

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
@@ -17,6 +17,7 @@ type ISalesmanInformationEditProps = {
   salesmanId: string;
   editForm: TSalesmanEditForm;
   companyOptions: TSalesmanCompanyOption[];
+  isCompanyEditable?: boolean;
   onFieldChange: (
     field: keyof Omit<TSalesmanEditForm, 'active'>,
     value: string
@@ -28,6 +29,7 @@ export const SalesmanInformationEdit = ({
   salesmanId,
   editForm,
   companyOptions,
+  isCompanyEditable = true,
   onFieldChange,
   onStatusChange,
 }: ISalesmanInformationEditProps): JSX.Element => {
@@ -64,6 +66,7 @@ export const SalesmanInformationEdit = ({
             value={editForm.companyId}
             onChange={(e) => onFieldChange('companyId', e.target.value)}
             fullWidth
+            disabled={!isCompanyEditable}
           >
             {companyOptions.map((option) => (
               <MenuItem key={option.id} value={option.id}>


### PR DESCRIPTION
## Issue relacionada

#67 

## O que foi implementado?

* Habilitada a edição de vendedores para o perfil GESTOR.
* Reutilizada a experiência de edição inline já existente no detalhe de vendedor.
* Adicionado suporte para que o gestor entre em modo de edição a partir da tela de detalhes.
* Formulário pré-preenchido com os dados atuais do vendedor.
* Campo Empresa mantido visível e não editável para gestores.
* Garantido que apenas a empresa atual do vendedor seja utilizada no fluxo do gestor.
* Mantido o comportamento existente para administradores.
* Adicionados testes para SalesmanDetail e SalesmanInformationEdit.

Além disso, foram realizados ajustes preparatórios identificados durante a revisão da FE-27:

* Remoção do campo telefone da visualização do vendedor.
* Evitado carregamento desnecessário da lista de empresas para usuários sem permissão de edição.

## Por que essa mudança é necessária?

O módulo GESTOR precisava permitir a edição de vendedores da sua equipe mantendo o mesmo padrão visual utilizado pelo ADMIN, porém respeitando as restrições de escopo e permissões do perfil.

Também foram corrigidas inconsistências identificadas durante a revisão da tela de detalhes, preparando a base para a edição sem impactar o fluxo administrativo.

## Como testar?

1. Acesse o sistema com um usuário ADMIN.
2. Abra o detalhe de um vendedor.
3. Verifique que a edição continua funcionando normalmente.
4. Acesse o sistema com um usuário GESTOR.
5. Abra o detalhe de um vendedor da sua equipe.
6. Clique em “Editar”.
7. Verifique que o formulário é carregado com os dados atuais.
8. Verifique que o campo Empresa permanece bloqueado para alteração.
9. Altere nome, email ou status e salve.
10. Confirme que os dados são atualizados corretamente.
11. Teste a ação “Cancelar” e confirme que as alterações locais são descartadas.

## Checklist

- [X] O código foi revisado pelo próprio autor antes de abrir o MR
- [X] A implementação não quebra funcionalidades existentes
- [X] Testes foram adicionados ou atualizados para cobrir as mudanças
