### PR TITLE
fix: company contact fields, double-submit, accent search, manager salesman edit

### DIFF
--- a/src/UI/AppModal/AppModal.test.tsx
+++ b/src/UI/AppModal/AppModal.test.tsx
@@ -53,4 +53,26 @@ describe('AppModal', () => {
     render(<AppModal {...defaultProps} open={false} />);
     expect(screen.queryByText('Adicionar empresa')).not.toBeInTheDocument();
   });
+
+  it('disables Salvar and Cancelar buttons when isSubmitting is true', () => {
+    render(<AppModal {...defaultProps} isSubmitting={true} />);
+    const buttons = screen.getAllByRole('button');
+    const salvar = buttons.find((b) => b.textContent?.includes('Salvar'));
+    const cancelar = buttons.find((b) => b.textContent?.includes('Cancelar'));
+    expect(salvar).toBeDisabled();
+    expect(cancelar).toBeDisabled();
+  });
+
+  it('does not call handleSubmit again when Salvar is clicked while isSubmitting', () => {
+    const handleSubmit = vi.fn();
+    render(
+      <AppModal
+        {...defaultProps}
+        handleSubmit={handleSubmit}
+        isSubmitting={true}
+      />
+    );
+    fireEvent.click(screen.getByText('Salvar'));
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/src/UI/AppModal/AppModal.tsx
+++ b/src/UI/AppModal/AppModal.tsx
@@ -1,4 +1,10 @@
-import { Box, Button, Stack, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
 import Modal from '@mui/material/Modal';
 import { GetAppIcon } from '@UI/AppIcon/AppIcon';
 import { ModalHeader } from '@UI/AppModal/ModalHeader/ModalHeader';
@@ -11,6 +17,7 @@ export interface IAppModalProps {
   handleSubmit: () => void;
   children: JSX.Element;
   isSaveButtonDisabled?: boolean;
+  isSubmitting?: boolean;
 }
 
 export const AppModal = ({
@@ -20,6 +27,7 @@ export const AppModal = ({
   handleClose,
   handleSubmit,
   isSaveButtonDisabled,
+  isSubmitting,
 }: IAppModalProps): JSX.Element => {
   return (
     <Modal open={open} onClose={handleClose}>
@@ -55,14 +63,22 @@ export const AppModal = ({
             variant="outlined"
             onClick={handleClose}
             startIcon={GetAppIcon('close')}
+            disabled={isSubmitting}
           >
             <Typography variant="body1">{'Cancelar'}</Typography>
           </Button>
           <Button
-            startIcon={GetAppIcon('save')}
+            startIcon={
+              isSubmitting ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : (
+                GetAppIcon('save')
+              )
+            }
             variant="contained"
-            disabled={isSaveButtonDisabled}
+            disabled={isSaveButtonDisabled || isSubmitting}
             onClick={() => {
+              if (isSubmitting) return;
               void handleSubmit();
             }}
           >

--- a/src/UI/DataTable/useDataTable.ts
+++ b/src/UI/DataTable/useDataTable.ts
@@ -10,6 +10,7 @@ import type {
 } from '@declarations/ui';
 import type { Palette } from '@mui/material/styles';
 import { alpha, useTheme } from '@mui/material/styles';
+import { normalizeText } from '@utils/normalizeText';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 
@@ -114,10 +115,7 @@ export const chipLookFromValue = (
   palette: Palette
 ): BadgeLook => {
   const raw = String(value ?? '').trim();
-  const normalized = raw
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+  const normalized = normalizeText(raw);
 
   if (/^ativo|active|enabled/.test(normalized)) {
     return scaleBgFg(

--- a/src/data/enums/EPageRoutes.ts
+++ b/src/data/enums/EPageRoutes.ts
@@ -7,7 +7,7 @@ export const EPageRoutes = {
   MANAGER_DETAIL: '/gestores/$id',
   SALESMEN: '/vendedores',
   SALESMAN_DETAIL: '/vendedores/$id',
-  MEETINGS: '/reuniões',
+  MEETINGS: '/reunioes',
 
-  SALESMAN_MEETINGS_DETAIL: '/reuniões/$meetingId',
+  SALESMAN_MEETINGS_DETAIL: '/reunioes/$meetingId',
 } as const;

--- a/src/pages/CompaniesPage/AddCompanyModal/AddCompanyModal.tsx
+++ b/src/pages/CompaniesPage/AddCompanyModal/AddCompanyModal.tsx
@@ -52,9 +52,11 @@ export const AddCompanyModal = ({
     }
   }, [open, reset]);
 
-  const { mutate: createCompany } = useCreateCompany();
+  const { mutate: createCompany, isPending } = useCreateCompany();
 
   const onSubmit = (data: TCompanyCreatePayload): void => {
+    if (isPending) return;
+
     createCompany(data, {
       onSuccess: () => {
         handleClose();
@@ -68,6 +70,7 @@ export const AddCompanyModal = ({
       open={open}
       handleClose={handleClose}
       isSaveButtonDisabled={!isValid}
+      isSubmitting={isPending}
       handleSubmit={handleSubmit(onSubmit)}
     >
       <Box

--- a/src/pages/CompaniesPage/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage/CompaniesPage.tsx
@@ -21,6 +21,7 @@ import { PageHeader } from '@UI/PageHeader/PageHeader';
 import { PlanBadge } from '@UI/PlanBadge/PlanBadge';
 import { StatCard } from '@UI/StatCard/StatCard';
 import { StatusBadge } from '@UI/StatusBadge/StatusBadge';
+import { normalizeText } from '@utils/normalizeText';
 import type { JSX, ReactNode } from 'react';
 import React, { useMemo, useState } from 'react';
 
@@ -58,13 +59,13 @@ export const CompaniesPage = (): JSX.Element => {
   );
 
   const filteredCompanies = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
+    const query = normalizeText(searchValue.trim());
     return companies.filter((company) => {
       if (filterValue === 'true' && !company.active) return false;
       if (filterValue === 'false' && company.active) return false;
       if (query.length === 0) return true;
-      const nameMatch = company.name.toLowerCase().includes(query);
-      const taxIdMatch = company.tax_id.toLowerCase().includes(query);
+      const nameMatch = normalizeText(company.name).includes(query);
+      const taxIdMatch = normalizeText(company.tax_id).includes(query);
       return nameMatch || taxIdMatch;
     });
   }, [companies, searchValue, filterValue]);

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationEdit/CompanyInformationEditFields/CompanyInformationEditFields.tsx
@@ -66,10 +66,11 @@ export const CompanyInformationEditFields = ({
           </Typography>
           <TextField
             fullWidth
-            value={'Rua Exemplo, 123'}
+            value={draft.address ?? ''}
             onChange={(e) =>
               setDraft((d) => ({ ...d, address: e.target.value }))
             }
+            helperText="Atualização de endereço ainda não é salva pela API."
             slotProps={{
               input: {
                 startAdornment: (
@@ -95,8 +96,9 @@ export const CompanyInformationEditFields = ({
           </Typography>
           <TextField
             fullWidth
-            value={'99999-9999'}
+            value={draft.phone ?? ''}
             onChange={(e) => setDraft((d) => ({ ...d, phone: e.target.value }))}
+            helperText="Atualização de telefone ainda não é salva pela API."
             slotProps={{
               input: {
                 startAdornment: (

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/CompanyInformationView.tsx
@@ -14,6 +14,8 @@ export const CompanyInformationView = ({
   tax_id,
   plan,
   active,
+  address,
+  phone,
 }: CompanyInformationValues): JSX.Element => (
   <Box
     sx={{
@@ -32,7 +34,7 @@ export const CompanyInformationView = ({
     </ItemDetail>
     <ItemDetail
       label="Endereço"
-      value="Rua Exemplo, 123"
+      value={address || 'Não informado'}
       icon={<LocationOnOutlinedIcon fontSize="small" />}
     />
     <ItemDetail label="Status">
@@ -42,7 +44,7 @@ export const CompanyInformationView = ({
     </ItemDetail>
     <ItemDetail
       label="Telefone"
-      value="99999-9999"
+      value={phone || 'Não informado'}
       icon={<PhoneOutlinedIcon fontSize="small" />}
     />
   </Box>

--- a/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/types.ts
+++ b/src/pages/CompaniesPage/CompanyDetail/CompanyInformation/CompanyInformationView/types.ts
@@ -6,6 +6,8 @@ export interface CompanyInformationValues {
   tax_id: string;
   plan: TPlan;
   active: boolean;
+  phone?: string | null;
+  address?: string | null;
 }
 
 export interface CompanyInformationProps extends CompanyInformationValues {

--- a/src/pages/ManagersPage/AddManagerModal/AddManagerModal.tsx
+++ b/src/pages/ManagersPage/AddManagerModal/AddManagerModal.tsx
@@ -53,9 +53,11 @@ export const AddManagerModal = ({
     }
   }, [open, reset]);
 
-  const { mutate: createManager } = useCreateManager();
+  const { mutate: createManager, isPending } = useCreateManager();
 
   const onSubmit = (data: TManagerCreatePayload): void => {
+    if (isPending) return;
+
     createManager(data, {
       onSuccess: () => {
         handleClose();
@@ -69,6 +71,7 @@ export const AddManagerModal = ({
       open={open}
       handleClose={handleClose}
       handleSubmit={handleSubmit(onSubmit)}
+      isSubmitting={isPending}
     >
       <Box
         sx={{

--- a/src/pages/ManagersPage/ManagersPage.tsx
+++ b/src/pages/ManagersPage/ManagersPage.tsx
@@ -18,6 +18,7 @@ import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import { StatCard } from '@UI/StatCard/StatCard';
 import { StatusBadge } from '@UI/StatusBadge/StatusBadge';
+import { normalizeText } from '@utils/normalizeText';
 import type { JSX, ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 
@@ -37,14 +38,14 @@ export const ManagersPage = (): JSX.Element => {
   );
 
   const filteredManagers = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
+    const query = normalizeText(searchValue.trim());
     return managers.filter((manager) => {
       if (filterValue === 'true' && !manager.active) return false;
       if (filterValue === 'false' && manager.active) return false;
       if (query.length === 0) return true;
-      const nameMatch = manager.name.toLowerCase().includes(query);
-      const emailMatch = manager.email.toLowerCase().includes(query);
-      const companyMatch = manager.company.name.toLowerCase().includes(query);
+      const nameMatch = normalizeText(manager.name).includes(query);
+      const emailMatch = normalizeText(manager.email).includes(query);
+      const companyMatch = normalizeText(manager.company.name).includes(query);
       return nameMatch || emailMatch || companyMatch;
     });
   }, [managers, searchValue, filterValue]);

--- a/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/MeetingDetail.tsx
+++ b/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingDetail/MeetingDetail.tsx
@@ -20,12 +20,12 @@ import { MeetingDetailTabsContent } from './components/MeetingDetailTabsContent'
 export const MeetingDetail = (): JSX.Element => {
   const { meetingId } = useParams({ strict: false }) as { meetingId: string };
   const search = useSearch({
-    from: '/protected/reuniões/$meetingId',
+    from: '/protected/reunioes/$meetingId',
   });
 
   const currentTab = (search.tab || 'context') as TMeetingTab;
   const navigate = useNavigate({
-    from: '/reuniões/$meetingId',
+    from: '/reunioes/$meetingId',
   });
 
   const {

--- a/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingsPage.test.tsx
+++ b/src/pages/MeetingsPage/SalesmanMeetingsPage/SalesmanMeetingsPage.test.tsx
@@ -107,7 +107,7 @@ describe('SalesmanMeetingsPage', () => {
       search: 'produto',
     });
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/reuniões/$meetingId',
+      to: '/reunioes/$meetingId',
       params: { meetingId: 'meeting-1' },
     });
   });

--- a/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
+++ b/src/pages/SalesmenPage/AddSalesmanModal/AddSalesmanModal.tsx
@@ -81,9 +81,11 @@ export const AddSalesmanModal = ({
     }
   }, [isManagerVariant, managerData?.company, setValue]);
 
-  const { mutate: createSalesman } = useCreateSalesman();
+  const { mutate: createSalesman, isPending } = useCreateSalesman();
 
   const onSubmit = (data: TCreateSalesman): void => {
+    if (isPending) return;
+
     createSalesman(data, {
       onSuccess: () => {
         handleClose();
@@ -115,6 +117,7 @@ export const AddSalesmanModal = ({
       open={open}
       handleClose={handleClose}
       handleSubmit={handleSubmit(onSubmit)}
+      isSubmitting={isPending}
       isSaveButtonDisabled={
         isManagerVariant &&
         (isManagerLoading || isManagerError || !managerData?.company)

--- a/src/pages/SalesmenPage/AdminSalesmenPage/AdminSalesmenPage.tsx
+++ b/src/pages/SalesmenPage/AdminSalesmenPage/AdminSalesmenPage.tsx
@@ -14,6 +14,7 @@ import { DataTable } from '@UI/DataTable/DataTable';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import { StatCard } from '@UI/StatCard/StatCard';
+import { normalizeText } from '@utils/normalizeText';
 import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 
@@ -36,14 +37,14 @@ export const AdminSalesmenPage = (): JSX.Element => {
   );
 
   const filteredSalesmen = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
+    const query = normalizeText(searchValue.trim());
     return salesmen.filter((salesman) => {
       if (filterValue === 'true' && !salesman.active) return false;
       if (filterValue === 'false' && salesman.active) return false;
       if (query.length === 0) return true;
-      const nameMatch = salesman.name.toLowerCase().includes(query);
-      const emailMatch = salesman.email.toLowerCase().includes(query);
-      const companyMatch = salesman.company.name.toLowerCase().includes(query);
+      const nameMatch = normalizeText(salesman.name).includes(query);
+      const emailMatch = normalizeText(salesman.email).includes(query);
+      const companyMatch = normalizeText(salesman.company.name).includes(query);
       return nameMatch || emailMatch || companyMatch;
     });
   }, [salesmen, searchValue, filterValue]);

--- a/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
+++ b/src/pages/SalesmenPage/ManagerSalesmenPage/ManagerSalesmenPage.tsx
@@ -14,6 +14,7 @@ import { DataTable } from '@UI/DataTable/DataTable';
 import { PageContainter } from '@UI/PageContainer/PageContainer';
 import { PageHeader } from '@UI/PageHeader/PageHeader';
 import { StatCard } from '@UI/StatCard/StatCard';
+import { normalizeText } from '@utils/normalizeText';
 import type { JSX } from 'react';
 import { useMemo, useState } from 'react';
 
@@ -34,13 +35,13 @@ export const ManagerSalesmenPage = (): JSX.Element => {
   );
 
   const filteredSalesmen = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
+    const query = normalizeText(searchValue.trim());
     return salesmen.filter((salesman) => {
       if (filterValue === 'true' && !salesman.active) return false;
       if (filterValue === 'false' && salesman.active) return false;
       if (query.length === 0) return true;
-      const nameMatch = salesman.name.toLowerCase().includes(query);
-      const emailMatch = salesman.email.toLowerCase().includes(query);
+      const nameMatch = normalizeText(salesman.name).includes(query);
+      const emailMatch = normalizeText(salesman.email).includes(query);
       return nameMatch || emailMatch;
     });
   }, [salesmen, searchValue, filterValue]);

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.test.tsx
@@ -56,29 +56,23 @@ describe('SalesmanInformationEdit', () => {
     expect(screen.queryByText(/papel|role/i)).not.toBeInTheDocument();
   });
 
-  it('enables company select by default (admin)', () => {
-    const { container } = render(<SalesmanInformationEdit {...defaultProps} />);
-    expect(
-      container.querySelector('.MuiInputBase-root.Mui-disabled')
-    ).not.toBeInTheDocument();
+  it('shows company select by default (admin)', () => {
+    render(<SalesmanInformationEdit {...defaultProps} />);
+    expect(screen.getByText('Empresa')).toBeInTheDocument();
   });
 
-  it('disables company select for manager (isCompanyEditable=false)', () => {
-    const { container } = render(
+  it('removes company field for manager (isCompanyEditable=false)', () => {
+    render(
       <SalesmanInformationEdit {...defaultProps} isCompanyEditable={false} />
     );
-    expect(
-      container.querySelector('.MuiInputBase-root.Mui-disabled')
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Empresa')).not.toBeInTheDocument();
   });
 
-  it('enables company select when isCompanyEditable=true', () => {
-    const { container } = render(
+  it('shows company select when isCompanyEditable=true', () => {
+    render(
       <SalesmanInformationEdit {...defaultProps} isCompanyEditable={true} />
     );
-    expect(
-      container.querySelector('.MuiInputBase-root.Mui-disabled')
-    ).not.toBeInTheDocument();
+    expect(screen.getByText('Empresa')).toBeInTheDocument();
   });
 
   it('calls onFieldChange when name is edited', () => {

--- a/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
+++ b/src/pages/SalesmenPage/SalesmanDetail/SalesmanInformationEdit/SalesmanInformationEdit.tsx
@@ -57,24 +57,25 @@ export const SalesmanInformationEdit = ({
           />
         </Box>
 
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            Empresa
-          </Typography>
-          <TextField
-            select
-            value={editForm.companyId}
-            onChange={(e) => onFieldChange('companyId', e.target.value)}
-            fullWidth
-            disabled={!isCompanyEditable}
-          >
-            {companyOptions.map((option) => (
-              <MenuItem key={option.id} value={option.id}>
-                {option.name}
-              </MenuItem>
-            ))}
-          </TextField>
-        </Box>
+        {isCompanyEditable && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              Empresa
+            </Typography>
+            <TextField
+              select
+              value={editForm.companyId}
+              onChange={(e) => onFieldChange('companyId', e.target.value)}
+              fullWidth
+            >
+              {companyOptions.map((option) => (
+                <MenuItem key={option.id} value={option.id}>
+                  {option.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+        )}
 
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>

--- a/src/services/models/CompanySchema.ts
+++ b/src/services/models/CompanySchema.ts
@@ -17,6 +17,8 @@ export const CompanySchema = z.object({
     }),
   plan: z.enum(['BASIC', 'PRO', 'ENTERPRISE']),
   active: z.boolean(),
+  phone: z.string().nullable().optional(),
+  address: z.string().nullable().optional(),
   created_at: z.string().optional(),
 });
 

--- a/src/utils/normalizeText.test.ts
+++ b/src/utils/normalizeText.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeText } from './normalizeText';
+
+describe('normalizeText', () => {
+  it('removes accents', () => {
+    expect(normalizeText('João')).toBe('joao');
+    expect(normalizeText('São Paulo')).toBe('sao paulo');
+    expect(normalizeText('Indústria')).toBe('industria');
+  });
+
+  it('lowercases the text', () => {
+    expect(normalizeText('MARIA')).toBe('maria');
+  });
+
+  it('keeps text without accents unchanged besides casing', () => {
+    expect(normalizeText('Bruno Souza')).toBe('bruno souza');
+  });
+
+  it('handles empty string', () => {
+    expect(normalizeText('')).toBe('');
+  });
+});

--- a/src/utils/normalizeText.ts
+++ b/src/utils/normalizeText.ts
@@ -1,0 +1,5 @@
+const DIACRITICS_REGEX = /[̀-ͯ]/g;
+
+/** Remove acentos e normaliza para minúsculas, para comparações de busca. */
+export const normalizeText = (value: string): string =>
+  value.toLowerCase().normalize('NFD').replace(DIACRITICS_REGEX, '');

--- a/src/utils/pickCompanyValues.ts
+++ b/src/utils/pickCompanyValues.ts
@@ -13,11 +13,16 @@ const isApiPlanCode = (plan: string): plan is CompanyPlanCode =>
 export const pickCompanyValues = (
   props:
     | CompanyInformationProps
-    | Pick<TCompany, 'id' | 'name' | 'tax_id' | 'plan' | 'active'>
+    | Pick<
+        TCompany,
+        'id' | 'name' | 'tax_id' | 'plan' | 'active' | 'phone' | 'address'
+      >
 ): CompanyInformationValues => ({
   id: props.id,
   name: props.name,
   tax_id: props.tax_id,
   plan: isApiPlanCode(props.plan) ? planApiToUiLabel[props.plan] : props.plan,
   active: props.active,
+  phone: props.phone,
+  address: props.address,
 });


### PR DESCRIPTION
## Resumo

Corrige 5 itens reportados:

### ADMIN
1. **Endereço/telefone não atualizavam no edit de empresa** — os campos tinham `value` fixado em string hardcoded (`'Rua Exemplo, 123'`, `'99999-9999'`). Conectados aos dados reais da empresa. A API de update ainda não persiste esses campos (combinado fazer só frontend por agora) — os campos mostram um helper text avisando disso.
2. **Criar gestor/vendedor: sem toast, modal não fecha, erro de duplicado** — o botão Salvar não tinha proteção contra duplo clique. Um segundo clique antes da 1ª chamada terminar disparava a mutation de novo, que falha com "já existe" no backend. Como o ToastProvider só guarda um toast por vez, o erro da 2ª chamada mascarava o sucesso da 1ª. Adicionado `isSubmitting` no `AppModal` para desabilitar os botões e mostrar loading durante o envio.

### Melhorias gerais
1. **Busca ignora acentos** — criado `normalizeText` util e aplicado nas 4 buscas client-side (empresas, gestores, vendedores admin/gestor).
2. **Campo Empresa no edit de vendedor pelo gestor** — já estava desabilitado, agora é removido da tela quando o usuário é gestor (não pode editar mesmo).
3. **Acento na URL de reuniões** — `/reuniões` → `/reunioes` em `EPageRoutes` e nos `from` do `useSearch`/`useNavigate` em `MeetingDetail.tsx`.

## Test plan
- [x] tsc limpo
- [x] 374 testes passando
- [x] lint limpo
- [x] Testes novos: `normalizeText.test.ts`, casos de `isSubmitting` no `AppModal.test.tsx`, ajuste do teste de remoção do campo Empresa, ajuste do path de navegação em `SalesmanMeetingsPage.test.tsx`
